### PR TITLE
dnsmasq: Add www.zephyrproject.org to address lists

### DIFF
--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -7,6 +7,8 @@ no-resolv
 
 address=/4.zephyr.test/192.0.2.2
 address=/6.zephyr.test/2001:db8::2
+address=/www.zephyrproject.org/192.0.2.2
+address=/www.zephyrproject.org/2001:db8::2
 
 # Add zephyrtest to /etc/hosts for next cname to work
 cname=ztest,zephyrtest

--- a/dnsmasq.sh
+++ b/dnsmasq.sh
@@ -1,1 +1,3 @@
-dnsmasq -C dnsmasq.conf -d
+#!/bin/sh
+
+exec dnsmasq -C dnsmasq.conf -d


### PR DESCRIPTION
This makes it easier for QA to execute the DNS sample programs without
requiring them to set up transparent proxies and/or routing/NAT.

Also add a shebang to dnsmasq.sh and change its permissions so it's
executable from the get go.

JIRA: ZEP-2040
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>