### PR TITLE
tunslip6: reload slip without restarting tap

### DIFF
--- a/loop-slip-tap.sh
+++ b/loop-slip-tap.sh
@@ -40,5 +40,5 @@ ctrl_c() {
 }
 
 while [ $STOPPED -eq 0 ]; do
-    $DIR/tunslip6 -T -s `readlink /tmp/slip.dev` 2001:db8::1/64 $@
+    $DIR/tunslip6 -T -s /tmp/slip.dev 2001:db8::1/64 $@
 done

--- a/tunslip6.c
+++ b/tunslip6.c
@@ -464,7 +464,11 @@ get_slipfd()
         }
       }
       if (timestamp) stamptime();
-      fprintf(stderr, "********SLIP started on ``/dev/%s''\n", siodev);
+      if (siodev[0] != '/') {
+        fprintf(stderr, "********SLIP started on ``/dev/%s''\n", siodev);
+      } else {
+        fprintf(stderr, "********SLIP started on ``%s''\n", siodev);
+      }
       stty_telos(fd);
     }
 


### PR DESCRIPTION
This makes testing compatible with programs which open a raw
socket on an interface and can't be told they need to reopen
their socket when the tap0 interface is recreated.

slipfd and inslip are reopened after a wait period when an
error occurs reading from inslip. This makes it so we don't
have to bring down the tap interface we can continue with the
new slip and the old tap in case other programs are using it.

Signed-off-by: John Andersen <john.s.andersen@intel.com>