### PR TITLE
tunslip6: Flush neighbor cache when qemu restarts

### DIFF
--- a/tunslip6.c
+++ b/tunslip6.c
@@ -375,6 +375,11 @@ serial_to_tun(FILE *inslip, int outfd)
 unsigned char slip_buf[2000];
 int slip_end, slip_begin;
 
+static void flush_neighbors(const char *tundev)
+{
+	ssystem("ip neigh flush dev %s", tundev);
+}
+
 int
 get_slipfd()
 {
@@ -482,6 +487,7 @@ get_slipfd()
     slipfd = fd;
 
     printf("slipfd and inslip reopened\n");
+    flush_neighbors(tundev);
     return 1;
   }
 


### PR DESCRIPTION
If the qemu is restarted, the tunslip6 notices it and reopens the
interface. But we should flush the neighbor cache as the MAC addresses
of the qemu zephyr instance will be changed but the IP addresses will
be the same. If we do not flush, then Linux will take several seconds
before connectivity is restored after qemu restart.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>