### PR TITLE
echo-server: Fix select() failed if tcp connection is closed by the peer

### DIFF
--- a/echo-server.c
+++ b/echo-server.c
@@ -581,20 +581,22 @@ int main(int argc, char**argv)
 			break;
 
 		/* TCP IPv4 */
-		if (tcp_receive_and_reply(&rfds, &errfds,
-					  accepted4, accepted4,
-					  buf, sizeof(buf),
-					  IPPROTO_TCP) < 0) {
+		ret = tcp_receive_and_reply(&rfds, &errfds,
+					    accepted4, accepted4,
+					    buf, sizeof(buf),
+					    IPPROTO_TCP);
+		if (ret < 0) {
 			break;
 		} else if (ret == 0) {
 			accepted4 = -1;
 		}
 
 		/* TCP IPv6 */
-		if (tcp_receive_and_reply(&rfds, &errfds,
-					  accepted6, accepted6,
-					  buf, sizeof(buf),
-					  IPPROTO_TCP) < 0) {
+		ret = tcp_receive_and_reply(&rfds, &errfds,
+					    accepted6, accepted6,
+					    buf, sizeof(buf),
+					    IPPROTO_TCP);
+		if (ret < 0) {
 			break;
 		} else if (ret == 0) {
 			accepted6 = -1;


### PR DESCRIPTION
Handle the return value of tcp_receive_and_reply() properly, so the
sockets returned by accept() will be reset to -1 if connection is
closed by the peer.

Signed-off-by: Aska.Wu <aska.wu@linaro.org>