### PR TITLE
tunslip6: increase SLIP buffer size to fit escape characters

### DIFF
--- a/tunslip6.c
+++ b/tunslip6.c
@@ -372,7 +372,7 @@ serial_to_tun(FILE *inslip, int outfd)
   goto read_more;
 }
 
-unsigned char slip_buf[2000];
+unsigned char slip_buf[3028];
 int slip_end, slip_begin;
 
 static void flush_neighbors(const char *tundev)


### PR DESCRIPTION
Ethernet frame of the size 1514 may contain lots of ESC and END
data bytes that need to be escaped, thus causing the resulting
packet to grow in size. Therefore, the current SLIP buffer size
of 2000 bytes in insufficient for one frame.

Fixes #16

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@linux.intel.com>