### PR TITLE
net-setup: Add a script to setup host ethernet interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,47 @@ Be sure to use Python 3, as it requires a function from the socket module
 that's only available in this version (wrapper around if_nametoindex(3)).
 
 
+## Using net-setup.sh script to setup host side ethernet interface
+
+The net-setup.sh script can setup an ethernet interface to the host.
+User is able to setup a configuration file that will contain
+commands to setup IP addresses and routes to the host interface.
+This net-setup.sh script will need to be run as a root user.
+
+If no parameters are given, then "zeth" network interface and "zeth.conf"
+configuration file are used. The script waits until user presses CTRL-c
+and then removes the network interface.
+```
+$ net-setup.sh
+```
+```
+$ net-setup.sh --config zeth-vlan.conf
+```
+```
+$ net-setup.sh --config my-own-config.conf --iface foobar
+```
+
+It is also possible to let the script return and then stop the network
+interface later. Is can be done by first creating the interface with
+"start" or "up" command, and then later remove the interface with
+"stop" or "down" command.
+```
+$ net-setup.sh start
+do your things here
+$ net-setup.sh stop
+```
+```
+$ net-setup.sh --config my-own-config.conf up
+do your things here
+$ net-setup.sh --config my-own-config.conf down
+```
+
+Any extra parameters that the script does not know, are passed directly
+to "ip" command.
+```
+$ net-setup.sh --config my-own-config.conf --iface foo user bar
+```
+
 ## Using encrypted SSL link with echo-* programs
 
 Install stunnel

--- a/net-setup.sh
+++ b/net-setup.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+    cat <<EOF
+$0 [--config|-c <file>] [--iface|-i <interface>] [start|up] [stop|down]
+               [any optional parameters for ip command]
+
+If no parameters are given, then "zeth" network interface and "zeth.conf"
+configuration file are used. The script waits until user presses CTRL-c
+and then removes the network interface.
+
+Examples:
+
+$ net-setup.sh
+$ net-setup.sh --config zeth-vlan.conf
+$ net-setup.sh --config my-own-config.conf --iface foobar
+
+It is also possible to let the script return and then stop the network
+interface later. Is can be done by first creating the interface with
+"start" or "up" command, and then later remove the interface with
+"stop" or "down" command.
+
+$ net-setup.sh start
+do your things here
+$ net-setup.sh stop
+
+$ net-setup.sh --config my-own-config.conf up
+do your things here
+$ net-setup.sh --config my-own-config.conf down
+
+Any extra parameters that the script does not know, are passed directly
+to "ip" command.
+
+$ net-setup.sh --config my-own-config.conf --iface foo user bar
+
+EOF
+    exit
+}
+
+if [ "$1" = "-h" -o "$1" = "--help" ]; then
+    usage
+fi
+
+if [ `id -u` != 0 ]; then
+    echo "Run this script as a root user!"
+    sudo $0 $@
+    exit
+fi
+
+IFACE=zeth
+
+# Default config file setups default connectivity IP addresses
+CONF_FILE=./zeth.conf
+
+while [ $# -gt 0 ]
+do
+    case $1 in
+	--config|-c)
+	    CONF_FILE="$2"
+	    shift 2
+	    ;;
+	--iface|-i)
+	    IFACE="$2"
+	    shift 2
+	    ;;
+	--help|-h)
+	    usage
+	    ;;
+	up|start)
+	    ACTION=start
+	    shift
+	    ;;
+	down|stop)
+	    ACTION=stop
+	    shift
+	    ;;
+	*)
+	    break
+	    ;;
+    esac
+done
+
+if [ ! -f "$CONF_FILE" ]; then
+    if [ ! -f "${0%/*}/$CONF_FILE" ];then
+	echo "No such file '$CONF_FILE'"
+	exit
+    fi
+
+    CONF_FILE="${0%/*}/$CONF_FILE"
+fi
+
+echo "Using $CONF_FILE configuration file."
+
+STOPPED=0
+trap ctrl_c INT TERM
+
+ctrl_c() {
+    STOPPED=1
+}
+
+if [ "$ACTION" != stop ]; then
+    echo "Creating $IFACE"
+    ip tuntap add $IFACE mode tap $@
+
+    # The idea is that the configuration file will setup
+    # the IP addresses etc. for the created interface.
+    . "$CONF_FILE" $IFACE
+fi
+
+if [ "$ACTION" = "" ]; then
+    while [ $STOPPED -eq 0 ]; do
+	sleep 1d
+    done
+fi
+
+if [ "$ACTION" != start ]; then
+    ip link set $IFACE down
+
+    echo "Removing $IFACE"
+    ip tuntap del $IFACE mode tap
+fi

--- a/zeth-vlan.conf
+++ b/zeth-vlan.conf
@@ -1,0 +1,45 @@
+# Configuration file for setting IP addresses for a network interface
+# and setting up two VLANs
+
+INTERFACE="$1"
+
+HWADDR="00:00:5e:00:53:ff"
+
+VLAN_NAME_PREFIX="vlan"
+VLAN_1_ID=100
+VLAN_2_ID=200
+
+PREFIX_1_IPV6="2001:db8:100"
+PREFIXLEN_1_IPV6="64"
+PREFIX_2_IPV6="2001:db8:200"
+PREFIXLEN_2_IPV6="64"
+
+# From RFC 5737
+PREFIX_1_IPV4="198.51.100"
+PREFIXLEN_1_IPV4="24"
+PREFIX_2_IPV4="203.0.113"
+PREFIXLEN_2_IPV4="24"
+
+ip link set dev ${INTERFACE} up
+
+ip link set dev ${INTERFACE} address ${HWADDR}
+
+ip link add link ${INTERFACE} name ${VLAN_NAME_PREFIX}.${VLAN_1_ID} type vlan id ${VLAN_1_ID}
+ip link add link ${INTERFACE} name ${VLAN_NAME_PREFIX}.${VLAN_2_ID} type vlan id ${VLAN_2_ID}
+
+ip link set ${VLAN_NAME_PREFIX}.${VLAN_1_ID} up
+ip link set ${VLAN_NAME_PREFIX}.${VLAN_2_ID} up
+
+ip -6 addr add ${PREFIX_1_IPV6}::2 dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+ip -6 route add ${PREFIX_1_IPV6}::/${PREFIXLEN_1_IPV6} \
+   dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+
+ip -6 addr add ${PREFIX_2_IPV6}::2 dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}
+ip -6 route add ${PREFIX_2_IPV6}::/${PREFIXLEN_2_IPV6} \
+   dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}
+
+ip addr add ${PREFIX_1_IPV4}.2 dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+ip route add ${PREFIX_1_IPV4}/${PREFIXLEN_1_IPV4} dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+
+ip addr add ${PREFIX_2_IPV4}.2 dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}
+ip route add ${PREFIX_2_IPV4}/${PREFIXLEN_2_IPV4} dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}

--- a/zeth.conf
+++ b/zeth.conf
@@ -1,0 +1,20 @@
+# Configuration file for setting IP addresses for a network interface.
+
+INTERFACE="$1"
+
+HWADDR="00:00:5e:00:53:ff"
+
+IPV6_ADDR_1="2001:db8::2"
+IPV6_ROUTE_1="2001:db8::/64"
+
+IPV4_ADDR_1="192.0.2.2"
+IPV4_ROUTE_1="192.0.2.0/24"
+
+ip link set dev $INTERFACE up
+
+ip link set dev $INTERFACE address $HWADDR
+
+ip -6 address add $IPV6_ADDR_1 dev $INTERFACE
+ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
+ip address add $IPV4_ADDR_1 dev $INTERFACE
+ip route add $IPV4_ROUTE_1 dev $INTERFACE


### PR DESCRIPTION
The net-setup.sh script can be used to create a ethernet network
interface to the host. The default name for the interface is
zeth, and default configuration file is zeth.conf.

Do ./net-setup.sh --help to see the usage.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>