### PR TITLE
ppp: Add instructions for using PPP in Zephyr

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,27 @@ Example:
 ```
 CONFIG_MBEDTLS_HEAP_SIZE=30000
 ```
+
+## PPP Connectivity
+
+You can test the PPP connectivity running in Qemu in Zephyr using pppd that is
+running in Linux host. You need to run *socat* and *pppd* to create
+a minimally working network setup.
+
+There are convenience scripts (_loop-ppp-dev.sh_ and _loop-pppd.sh_) for
+running socat and pppd processes. For running these, you need two
+terminals.
+
+Terminal 1:
+```
+$ ./loop-ppp-dev.sh
+```
+
+Terminal 2:
+```
+$ sudo ./loop-pppd.sh
+```
+
+After this, start PPP enabled Zephyr application. For example Zephyr
+*echo-server* sample in samples/net/sockets/echo_server has _overlay-ppp.conf_
+file that enables PPP support.

--- a/loop-ppp-dev.sh
+++ b/loop-ppp-dev.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run socat in a loop. This way we can restart pppd and do not need
+# to manually restart socat.
+
+STOPPED=0
+trap ctrl_c INT TERM
+
+ctrl_c() {
+    STOPPED=1
+}
+
+# If this file entry already exists, socat may complain
+rm -f /tmp/ppp
+
+while [ $STOPPED -eq 0 ]; do
+    socat $* PTY,link=/tmp/ppp.dev UNIX-LISTEN:/tmp/ppp
+    sleep 2
+done

--- a/loop-pppd.sh
+++ b/loop-pppd.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEV=/tmp/ppp.dev
+
+if [ ! -L "$DEV" ]; then
+    echo "The $DEV is not a symbolic link to PTY."
+    echo "Please run loop-ppp-dev.sh script to create it."
+    exit 1
+fi
+
+PTS_DEV=`find $DEV -ls -type l | awk -F' ' '{ print $13 }'`
+
+STOPPED=0
+trap ctrl_c INT TERM
+
+ctrl_c() {
+    STOPPED=1
+}
+
+while [ $STOPPED -eq 0  ]; do
+    pppd $PTS_DEV +ipv6 local \
+	 noauth novj noccp noaccomp nodefaultroute nomp nodetach \
+	 debug silent 192.0.2.2:192.0.2.1
+    sleep 2
+done


### PR DESCRIPTION
Two helper scripts, loop-ppp-dev.sh and loop-pppd.sh,
can be used when testing PPP.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>