### PR TITLE
net-setup: zeth-dhcp.conf: Add DHCP and SLAAC support to zeth

### DIFF
--- a/zeth-dhcp.conf
+++ b/zeth-dhcp.conf
@@ -1,0 +1,56 @@
+# Configuration file for setting DHCPv4 address for a network interface.
+
+INTERFACE="$1"
+
+HWADDR="00:00:5e:00:53:ff"
+
+# Local IP address configuration
+IPV6_ADDR_1="2001:db8::2"
+IPV6_ROUTE_1="2001:db8::/64"
+IPV4_ADDR_1="192.0.2.2/24"
+IPV4_ROUTE_1="192.0.2.0/24"
+
+# DHCPv4 configuration we offer to the zephyr instance
+IPV4_ADDR_LOW=192.0.2.3
+IPV4_ADDR_HIGH=192.0.2.254
+IPV4_ADDR_NETMASK=255.255.255.0
+IPV4_ADDR_BROADCAST=192.0.2.255
+LEASETIME=1h
+
+# IPv6 router advertisement parameters
+IPV6_RA_MTU=1280
+IPV6_RA_INTERVAL=60
+IPV6_RA_LIFETIME=600
+
+DNS_SERVER=localhost
+DNS_SERVER_PORT=15353
+
+# Set a proper domain name if needed
+DOMAINNAME="zephyr.domain"
+
+TMP_FILE=/tmp/.net-setup.dhcpv4.$$.conf
+
+ip link set dev $INTERFACE up
+
+ip link set dev $INTERFACE address $HWADDR
+
+ip -6 address add $IPV6_ADDR_1 dev $INTERFACE
+ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
+
+ip address add $IPV4_ADDR_1 dev $INTERFACE
+ip route add $IPV4_ROUTE_1 dev $INTERFACE
+
+sleep 1
+
+cat > $TMP_FILE <<EOF
+# DHCPv4 configuration file. Add any other options needed into this file.
+
+EOF
+
+dnsmasq --interface $INTERFACE --port=0 --bind-interfaces --no-resolv \
+	--dhcp-range=${IPV4_ADDR_LOW},${IPV4_ADDR_HIGH},${IPV4_ADDR_NETMASK},${IPV4_ADDR_BROADCAST},${LEASETIME} \
+	--dhcp-range=::3,::254,constructor:${INTERFACE},slaac,64 --enable-ra \
+	--ra-param=${INTERFACE},mtu:${IPV6_RA_MTU},${IPV6_RA_INTERVAL},${IPV6_RA_LIFETIME} \
+	--dhcp-authoritative -s $DOMAINNAME -C $TMP_FILE -x $PIDFILE
+
+rm -f $TMP_FILE


### PR DESCRIPTION
Add a configuration file that can start DHCP for IPv4 and SLAAC
for IPv6 using dnsmasq.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>