### PR TITLE
zeth: No need to setup IPv4 route

### DIFF
--- a/zeth.conf
+++ b/zeth.conf
@@ -17,4 +17,4 @@ ip link set dev $INTERFACE address $HWADDR
 ip -6 address add $IPV6_ADDR_1 dev $INTERFACE nodad
 ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
 ip address add $IPV4_ADDR_1 dev $INTERFACE
-ip route add $IPV4_ROUTE_1 dev $INTERFACE
+ip route add $IPV4_ROUTE_1 dev $INTERFACE > /dev/null 2>&1


### PR DESCRIPTION
As the IPv4 address setup sets the route to the 192.0.2.0/24
subnet, there is no need to explicitly set the route to that
subnet.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>