### PR TITLE
zeth: Do not enable DAD for added IPv6 address

### DIFF
--- a/zeth.conf
+++ b/zeth.conf
@@ -14,7 +14,7 @@ ip link set dev $INTERFACE up
 
 ip link set dev $INTERFACE address $HWADDR
 
-ip -6 address add $IPV6_ADDR_1 dev $INTERFACE
+ip -6 address add $IPV6_ADDR_1 dev $INTERFACE nodad
 ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
 ip address add $IPV4_ADDR_1 dev $INTERFACE
 ip route add $IPV4_ROUTE_1 dev $INTERFACE


### PR DESCRIPTION
DAD should not be done so that the added IPv6 address gets added
as a non-tentative address. Reason for this is that otherwise
one cannot start for example echo-server before starting qemu.
If the 2001:db8::2 address is tentative, then echo-server cannot
start unless qemu is started first. As the added IP addresses
are "fixed" in our setup, there is no need to do DAD anyway.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>