### PR TITLE
Run networking samples against Docker net-tools container

### DIFF
--- a/README.docker
+++ b/README.docker
@@ -1,0 +1,54 @@
+# Testing with net-tools and Docker
+
+* Create Docker image
+
+	cd docker/
+	docker build -t net-tools .
+
+* Setup network interfaces, IP addresses and routes
+
+	./net-setup.sh --config docker.conf
+
+* Run Docker image
+
+  Set the docker internal network name to the value $DOCKER_USER_INTERFACE
+  in docker.config above, default is 'net-tools0'. The bridge network that
+  docker creates will be printed on standard out, it's bridge interface
+  name will be br-XXXXXXXXXXXX. Check that the IPv4 and IPv6 addresses
+  given on the docker command line match the subnets in 'docker.conf'.
+
+  Interactively:
+
+	docker run --hostname=zephyr --name=net-tools \
+	       --ip=192.0.2.2 --ip6=2001:db8::2 \
+	       --rm -it --network=net-tools0 net-tools sh
+
+        exit with Ctrl-p ctrl-q to execute tests from the command line
+
+  Non-interactively
+
+	docker run --hostname=zephyr --name=net-tools \
+	       --ip=192.0.2.2 --ip6=2001:db8::2 \
+	       --rm -dt --network=net-tools0 net-tools sh
+
+* Run Qemu / native-posix image
+
+	rm -rf build && mkdir build
+
+	cmake -GNinja -DBOARD=native_posix -B build
+	   or
+	cmake -GNinja -DBOARD=qemu_x86 -DOVERLAY_CONFIG=overlay-e1000.conf \
+	   -B build
+
+	ninja -C build run
+
+* Execute tests like echo-client
+
+	docker container exec net-tools /net-tools/echo-client 2001:db8::1
+	docker container exec net-tools /net-tools/echo-client -t 2001:db8::1
+	docker container exec net-tools /net-tools/echo-client 192.0.2.1
+	docker container exec net-tools /net-tools/echo-client -t 192.0.2.1
+
+* Remove the 'net-tools0' docker network:
+
+	docker network rm net-tools0

--- a/docker.conf
+++ b/docker.conf
@@ -1,0 +1,29 @@
+# Configuration file for setting IP addresses for a network interface.
+
+INTERFACE="$1"
+DOCKER_USER_INTERFACE=net-tools0
+
+HWADDR="00:00:5e:00:53:ff"
+
+IPV6_ADDR_1="2001:db8::254"
+IPV6_ROUTE_1="2001:db8::/64"
+
+IPV4_ADDR_1="192.0.2.254"
+IPV4_ROUTE_1="192.0.2.0/24"
+
+DOCKER_INTERFACE=$( docker network create \
+		    --subnet $IPV4_ROUTE_1 \
+		    --gateway $IPV4_ADDR_1 \
+		    --ipv6=true \
+		    --subnet $IPV6_ROUTE_1 \
+		    --gateway $IPV6_ADDR_1 \
+		    $DOCKER_USER_INTERFACE )
+DOCKER_INTERFACE="br-$(echo $DOCKER_INTERFACE | cut -c -12)"
+
+ip link set dev $INTERFACE address $HWADDR
+
+brctl addif $DOCKER_INTERFACE $INTERFACE
+
+ip link set dev $INTERFACE up
+
+echo $DOCKER_INTERFACE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+# Create Docker image that can be used for testing Zephyr network
+# sample applications.
+
+FROM fedora
+FROM gcc
+
+# RUN http_proxy=... git clone...
+RUN git clone http://github.com/zephyrproject-rtos/net-tools.git && \
+    make /net-tools/tunslip6 && make /net-tools/echo-client && \
+    make /net-tools/echo-server && make /net-tools/throughput-client
+
+WORKDIR /net-tools
+
+# We do not run any command automatically but let the test script run
+# the proper test application script.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,10 @@ FROM gcc
 
 # RUN http_proxy=... git clone...
 RUN git clone http://github.com/zephyrproject-rtos/net-tools.git && \
-    make /net-tools/tunslip6 && make /net-tools/echo-client && \
-    make /net-tools/echo-server && make /net-tools/throughput-client
+    cd /net-tools && \
+    make tunslip6 && make echo-client && \
+    make echo-server && make throughput-client && \
+    make coap-client
 
 WORKDIR /net-tools
 

--- a/libcoap/examples/etsi_coaptest.sh
+++ b/libcoap/examples/etsi_coaptest.sh
@@ -36,6 +36,7 @@ testgroups=( CORE LINK BLOCK OBS )
 testnumber=-1
 group=''
 
+cd "$(dirname $0)"
 source etsi_testcases.sh
 
 function usage {


### PR DESCRIPTION
Improve Docker container creation and the network setup script needed to run net-tools container against Zephyr samples. See also the 'docker_samples' branch in Zephyr.