### PR TITLE
docker: Properly return values when network is already enabled

### DIFF
--- a/docker.conf
+++ b/docker.conf
@@ -18,12 +18,20 @@ DOCKER_INTERFACE=$( docker network create \
 		    --subnet $IPV6_ROUTE_1 \
 		    --gateway $IPV6_ADDR_1 \
 		    $DOCKER_USER_INTERFACE )
-DOCKER_INTERFACE="br-$(echo $DOCKER_INTERFACE | cut -c -12)"
 
-ip link set dev $INTERFACE address $HWADDR
+if [ $? -eq 0 ]
+then
+	DOCKER_INTERFACE="br-$(echo $DOCKER_INTERFACE | cut -c -12)"
 
-brctl addif $DOCKER_INTERFACE $INTERFACE
+	ip link set dev $INTERFACE address $HWADDR
 
-ip link set dev $INTERFACE up
+	brctl addif $DOCKER_INTERFACE $INTERFACE
+
+	ip link set dev $INTERFACE up
+else
+	DOCKER_INTERFACE=br-"$(docker network ls | \
+			 grep $DOCKER_USER_INTERFACE | \
+			 (read br rest ; echo $br) )"
+fi
 
 echo $DOCKER_INTERFACE


### PR DESCRIPTION
Fix the docker and net-setup.sh script to take into account that
docker and the network is already running.

Signed-off-by: Patrik Flykt <patrik.flykt@linux.intel.com>