### PR TITLE
docker: Add mosquitto MQTT server to net-tools image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,46 @@
 # Create Docker image that can be used for testing Zephyr network
 # sample applications.
 
-FROM fedora
 FROM gcc
 
-# RUN http_proxy=... git clone...
-RUN git clone http://github.com/zephyrproject-rtos/net-tools.git && \
+# RUN https_proxy=... git clone...
+RUN git clone https://github.com/zephyrproject-rtos/net-tools.git && \
     cd /net-tools && \
     make tunslip6 && make echo-client && \
     make echo-server && make throughput-client && \
     make coap-client
+
+# RUN https_proxy=... git clone...
+RUN git clone https://github.com/eclipse/mosquitto.git && \
+    cd /mosquitto && \
+    git checkout v1.6.9 && \
+    make binary && \
+    install -d /usr/local/bin/ && \
+    install -d /usr/local/sbin/ && \
+    install -d /usr/local/lib/ && \
+    install -s -m755 /mosquitto/client/mosquitto_pub \
+	       /usr/local/bin/mosquitto_pub && \
+    install -s -m755 /mosquitto/client/mosquitto_rr \
+	       /usr/local/bin/mosquitto_rr && \
+    install -s -m755 /mosquitto/client/mosquitto_sub \
+	       /usr/local/bin/mosquitto_sub && \
+    install -s -m644 /mosquitto/lib/libmosquitto.so.1 \
+	       /usr/local/lib/libmosquitto.so.1 && \
+    install -s -m755 /mosquitto/src/mosquitto /usr/local/sbin/mosquitto && \
+    install -s -m755 /mosquitto/src/mosquitto_passwd \
+	       /usr/local/bin/mosquitto_passwd && \
+    rm -rf /mosquitto
+
+RUN addgroup --system mosquitto && \
+    adduser --system \
+    --no-create-home \
+    --disabled-password \
+    --disabled-login \
+    --ingroup mosquitto \
+    mosquitto
+
+COPY mosquitto.conf /usr/local/etc/
+COPY mosquitto-tls.conf /usr/local/etc/
 
 WORKDIR /net-tools
 

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -1,0 +1,9 @@
+# Place your local configuration in /etc/mosquitto/conf.d/
+#
+# A full description of the configuration file is at
+# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
+
+pid_file /var/run/mosquitto.pid
+
+persistence true
+persistence_location /var/lib/mosquitto/


### PR DESCRIPTION
In addition to the already existing net tools, clone mosquitto
MQTT server from git, compile and install it. When running the
git clone, add any possible proxies as environment variables in
both RUN commands, e.g.:

   RUN https_proxy=proxy.example.net:112 git clone https://...

When mosquitto compilation is finished, install it in the Docker
image under /usr/local/ and remove the source code and build
directory. Mosquitto also needs a user id 'mosquitto'.

As multiple FROM directives are not that helpful, count on the
gcc image to contain necessary tools and build environment.

Signed-off-by: Patrik Flykt <patrik.flykt@linux.intel.com>