### PR TITLE
docker: Add mosquitto configuration file for TLS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,8 @@ RUN git clone https://github.com/eclipse/mosquitto.git && \
     install -d /usr/local/bin/ && \
     install -d /usr/local/sbin/ && \
     install -d /usr/local/lib/ && \
+    install -d /usr/local/etc/mosquitto/certs && \
+    install -d /var/lib/mosquitto && \
     install -s -m755 /mosquitto/client/mosquitto_pub \
 	       /usr/local/bin/mosquitto_pub && \
     install -s -m755 /mosquitto/client/mosquitto_rr \
@@ -39,8 +41,8 @@ RUN addgroup --system mosquitto && \
     --ingroup mosquitto \
     mosquitto
 
-COPY mosquitto.conf /usr/local/etc/
-COPY mosquitto-tls.conf /usr/local/etc/
+COPY mosquitto.conf /usr/local/etc/mosquitto/
+COPY mosquitto-tls.conf /usr/local/etc/mosquitto/
 
 WORKDIR /net-tools
 

--- a/docker/mosquitto-tls.conf
+++ b/docker/mosquitto-tls.conf
@@ -1,0 +1,21 @@
+# Place your local configuration in /etc/mosquitto/conf.d/
+#
+# A full description of the configuration file is at
+# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
+
+pid_file /var/run/mosquitto.pid
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+port 8883
+
+tls_version tlsv1.2
+
+require_certificate false
+allow_anonymous true
+
+cafile /net-tools/echo-apps-cert.pem
+
+certfile /net-tools/echo-apps-cert.pem
+keyfile /net-tools/echo-apps-key.pem


### PR DESCRIPTION
Add TLS configuration so that mosquitto runs on port 8883 with TLS
enabled. Install mosquitto configuration files to
/usr/local/etc/mosquitto. Install also missing directory in /var.

Re-use certificates from echo sample application with mosquitto.

Signed-off-by: Patrik Flykt <patrik.flykt@linux.intel.com>