### PR TITLE
docker: Add dante SOCKS 5 proxy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,11 @@ RUN addgroup --system mosquitto && \
 COPY mosquitto.conf /usr/local/etc/mosquitto/
 COPY mosquitto-tls.conf /usr/local/etc/mosquitto/
 
+# RUN http_proxy=... apt...
+RUN apt update && apt install dante-server -y
+
+COPY danted.conf /etc/
+
 WORKDIR /net-tools
 
 # We do not run any command automatically but let the test script run

--- a/docker/danted.conf
+++ b/docker/danted.conf
@@ -1,0 +1,14 @@
+internal: 192.0.2.2
+external: 192.0.2.2
+external: 127.0.0.1
+socksmethod: none
+user.unprivileged: nobody
+
+client pass {
+        from: 0.0.0.0/0 to: 0.0.0.0/0
+}
+
+socks pass {
+        from: 0.0.0.0/0 to: 0.0.0.0/0
+        protocol: tcp udp
+}

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -5,5 +5,7 @@
 
 pid_file /var/run/mosquitto.pid
 
+port 1883
+
 persistence true
 persistence_location /var/lib/mosquitto/


### PR DESCRIPTION
Install danted SOCKS 5 proxy and configuration file to the
image. Move mosquitto port definition to the configuration
file so that any script running mosquitto from the Docker
image does not need to specify the port.

Signed-off-by: Patrik Flykt <patrik.flykt@linux.intel.com>