### PR TITLE
Add VLAN priority support to echo-client and zeth

### DIFF
--- a/echo-client.c
+++ b/echo-client.c
@@ -421,6 +421,20 @@ static void signal_handler(int sig)
 	do_exit = true;
 }
 
+static int set_sock_priority(int sock)
+{
+	int priority = random() % 8;
+	int ret = 0;
+
+	ret = setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &priority,
+			 sizeof(priority));
+	if (ret < 0) {
+		perror("Cannot set socket priority");
+	}
+
+	return ret;
+}
+
 extern int optind, opterr, optopt;
 extern char *optarg;
 
@@ -432,7 +446,7 @@ extern char *optarg;
 int main(int argc, char**argv)
 {
 	int c, ret, fd, i = 0, timeout = -1, port = SERVER_PORT;
-	bool flood = false, multicast = false;
+	bool flood = false, multicast = false, classify = false;
 	struct sockaddr_in6 addr6_send = { 0 }, addr6_recv = { 0 };
 	struct sockaddr_in addr4_send = { 0 }, addr4_recv = { 0 };
 	struct sockaddr *addr_send, *addr_recv;
@@ -452,10 +466,13 @@ int main(int argc, char**argv)
 
 	opterr = 0;
 
-	while ((c = getopt(argc, argv, "Fi:p:eth")) != -1) {
+	while ((c = getopt(argc, argv, "Fci:p:eth")) != -1) {
 		switch (c) {
 		case 'F':
 			flood = true;
+			break;
+		case 'c':
+			classify = true;
 			break;
 		case 'i':
 			interface = optarg;
@@ -491,6 +508,9 @@ int main(int argc, char**argv)
 		printf("-p Use this port, default port is %d\n", SERVER_PORT);
 		printf("-r Check data by reversing it (needed when checking "
 		       "legacy stack\n");
+		printf("-c Classify (use 802.1Q defined priorities) the sent "
+		       "packets. The packet priority is used for UDP. "
+		       "This also requires VLAN to be used.\n");
 		printf("-F (flood) option will prevent the client from "
 		       "waiting the data.\n"
 		       "   The -F option will stress test the server.\n");
@@ -601,6 +621,8 @@ int main(int argc, char**argv)
 			perror("connect");
 			exit(-errno);
 		}
+
+		classify = false;
 	}
 
 again:
@@ -625,9 +647,17 @@ again:
 					sent += data[i].len;
 					pos += ret;
 				} while (sent < data[i].len);
-			} else
+			} else {
+				if (classify) {
+					ret = set_sock_priority(fd);
+					if (ret < 0)
+						goto out;
+				}
+
 				ret = sendto(fd, data[i].buf, data[i].len, 0,
 					     addr_send, addr_len);
+			}
+
 			if (ret < 0) {
 				perror("send");
 				goto out;

--- a/zeth-vlan-priority.conf
+++ b/zeth-vlan-priority.conf
@@ -1,0 +1,71 @@
+# Configuration file for setting IP addresses for a network interface
+# and setting up two VLANs and one non-VLAN interfaces.
+
+INTERFACE="$1"
+
+HWADDR="00:00:5e:00:53:ff"
+
+VLAN_NAME_PREFIX="vlan"
+VLAN_1_ID=100
+VLAN_2_ID=200
+
+PREFIX_1_IPV6="2001:db8:100"
+PREFIXLEN_1_IPV6="64"
+PREFIX_2_IPV6="2001:db8:200"
+PREFIXLEN_2_IPV6="64"
+
+# From RFC 5737
+PREFIX_1_IPV4="198.51.100"
+PREFIXLEN_1_IPV4="24"
+PREFIX_2_IPV4="203.0.113"
+PREFIXLEN_2_IPV4="24"
+
+IPV6_ADDR_1="2001:db8::2"
+IPV6_ROUTE_1="2001:db8::/64"
+
+IPV4_ADDR_1="192.0.2.2/24"
+IPV4_ROUTE_1="192.0.2.0/24"
+
+ip link set dev ${INTERFACE} up
+
+ip link set dev ${INTERFACE} address ${HWADDR}
+
+ip -6 address add ${IPV6_ADDR_1} dev ${INTERFACE}
+ip -6 route add ${IPV6_ROUTE_1} dev ${INTERFACE}
+ip address add ${IPV4_ADDR_1} dev ${INTERFACE}
+ip route add ${IPV4_ROUTE_1} dev ${INTERFACE}
+
+iptables -t mangle -A POSTROUTING -o ${VLAN_NAME_PREFIX}.${VLAN_1_ID} \
+	 -j CLASSIFY --set-class "0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7"
+ip link add link ${INTERFACE} name ${VLAN_NAME_PREFIX}.${VLAN_1_ID} \
+	type vlan id ${VLAN_1_ID} \
+	ingress-qos-map 0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7 \
+	egress-qos-map 0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7
+
+iptables -t mangle -A POSTROUTING -o ${VLAN_NAME_PREFIX}.${VLAN_2_ID} \
+	 -j CLASSIFY --set-class "0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7"
+ip link add link ${INTERFACE} name ${VLAN_NAME_PREFIX}.${VLAN_2_ID} \
+	type vlan id ${VLAN_2_ID} \
+	ingress-qos-map 0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7 \
+	egress-qos-map 0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7
+
+ip link set ${VLAN_NAME_PREFIX}.${VLAN_1_ID} up
+ip link set ${VLAN_NAME_PREFIX}.${VLAN_2_ID} up
+
+ip -6 addr add ${PREFIX_1_IPV6}::2 dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+ip -6 route add ${PREFIX_1_IPV6}::/${PREFIXLEN_1_IPV6} \
+   dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+
+ip -6 addr add ${PREFIX_2_IPV6}::2 dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}
+ip -6 route add ${PREFIX_2_IPV6}::/${PREFIXLEN_2_IPV6} \
+   dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}
+
+ip addr add ${PREFIX_1_IPV4}.2/${PREFIXLEN_1_IPV4} \
+	dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+ip route add ${PREFIX_1_IPV4}/${PREFIXLEN_1_IPV4} \
+	dev ${VLAN_NAME_PREFIX}.${VLAN_1_ID}
+
+ip addr add ${PREFIX_2_IPV4}.2/${PREFIXLEN_2_IPV4} \
+	dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}
+ip route add ${PREFIX_2_IPV4}/${PREFIXLEN_2_IPV4} \
+	dev ${VLAN_NAME_PREFIX}.${VLAN_2_ID}


### PR DESCRIPTION
Add -c option to echo-client. This option will randomly assign socket priority to the sent packet. Add also commands that map the socket priority to VLAN priority so that the recipient application (echo-server) is able to place packets to different RX queues. This will allow testing of RX queing.