### PR TITLE
docker: gptp: Add linuxptp daemon support to docker

### DIFF
--- a/docker.conf
+++ b/docker.conf
@@ -27,6 +27,10 @@ then
 
 	brctl addif $DOCKER_INTERFACE $INTERFACE
 
+	# By default the LLDP packets are not crossing the bridge interface
+	# so need to enable it here.
+	echo 16384 > /sys/class/net/${DOCKER_INTERFACE}/bridge/group_fwd_mask
+
 	ip link set dev $INTERFACE up
 else
 	DOCKER_INTERFACE=br-"$(docker network ls | \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,9 +49,19 @@ RUN apt update && apt install dante-server -y
 
 COPY danted.conf /etc/
 
+
 # Simple Python based HTTP server for http-client API testing
 COPY http-server.py /usr/local/bin
 COPY https-server.py /usr/local/bin
+
+# RUN https_proxy=... git clone...
+RUN git clone https://git.code.sf.net/p/linuxptp/code linuxptp && \
+    cd /linuxptp && \
+    git checkout v3.1 && \
+    make && \
+    make install
+
+COPY gptp.cfg /etc/
 
 WORKDIR /net-tools
 

--- a/docker/gptp.cfg
+++ b/docker/gptp.cfg
@@ -1,0 +1,80 @@
+[global]
+#
+# Default Data Set
+#
+twoStepFlag		1
+gmCapable		1
+priority1		200
+priority2		200
+domainNumber		0
+#utc_offset		37
+clockClass		248
+clockAccuracy		0xFD
+offsetScaledLogVariance	0xFFFF
+free_running		0
+freq_est_interval	1
+#
+# Port Data Set
+#
+logAnnounceInterval	1
+logSyncInterval		-3
+logMinPdelayReqInterval	0
+announceReceiptTimeout	3
+syncReceiptTimeout	3
+delayAsymmetry		0
+fault_reset_interval	4
+#neighborPropDelayThresh	800
+#neighborPropDelayThresh	10000
+#neighborPropDelayThresh	800000
+neighborPropDelayThresh	12000000
+min_neighbor_prop_delay	-20000000
+#
+# Run time options
+#
+assume_two_step		1
+logging_level		6
+path_trace_enabled	1
+follow_up_info		1
+hybrid_e2e		0
+tx_timestamp_timeout	1000
+use_syslog		0
+verbose			0
+summary_interval	3
+kernel_leap		1
+check_fup_sync		0
+#
+# Servo options
+#
+pi_proportional_const	0.0
+pi_integral_const	0.0
+pi_proportional_scale	0.0
+pi_proportional_exponent	-0.3
+pi_proportional_norm_max	0.7
+pi_integral_scale	0.0
+pi_integral_exponent	0.4
+pi_integral_norm_max	0.3
+step_threshold		0.0
+first_step_threshold	0.00002
+max_frequency		900000000
+clock_servo		pi
+sanity_freq_limit	200000000
+ntpshm_segment		0
+#
+# Transport options
+#
+transportSpecific	0x1
+ptp_dst_mac		01:80:C2:00:00:0E
+p2p_dst_mac		01:80:C2:00:00:0E
+uds_address		/var/run/ptp4l
+#
+# Default interface options
+#
+network_transport	L2
+delay_mechanism		P2P
+time_stamping		hardware
+tsproc_mode		filter
+delay_filter		moving_median
+delay_filter_length	10
+egressLatency		0
+ingressLatency		0
+boundary_clock_jbod	0


### PR DESCRIPTION
This allows us to run Linux gptp daemon against Zephyr gptp
sample application and to verify that the gptp stack is working
somehow.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>