### PR TITLE
docker: Add http(s)-server.py to the container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,10 @@ RUN apt update && apt install dante-server -y
 
 COPY danted.conf /etc/
 
+# Simple Python based HTTP server for http-client API testing
+COPY http-server.py /usr/local/bin
+COPY https-server.py /usr/local/bin
+
 WORKDIR /net-tools
 
 # We do not run any command automatically but let the test script run

--- a/docker/http-server.py
+++ b/docker/http-server.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python2
+
+import socket
+from BaseHTTPServer import HTTPServer
+from SimpleHTTPServer import SimpleHTTPRequestHandler
+
+PORT = 8000
+
+class HTTPServerV6(HTTPServer):
+    address_family = socket.AF_INET6
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    length = 0
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.send_header('Content-Length', str(self.length))
+        self.end_headers()
+
+    def do_POST(self):
+        payload = "<html><p>Done</p></html>"
+        self.length = len(payload)
+        self._set_headers()
+        self.wfile.write(payload)
+
+def main():
+    httpd = HTTPServerV6(("", PORT), RequestHandler)
+    print "Serving at port", PORT
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    main()

--- a/docker/https-server.py
+++ b/docker/https-server.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python2
+
+# HTTPS server test application.
+#
+# You can generate certificate file like this:
+#       openssl req -x509 -newkey rsa:2048 -keyout https-server.pem \
+#               -out https-server.pem -days 10000 -nodes \
+#               -subj '/CN=localhost'
+#
+# To see the contents of the certificate do this:
+#       openssl x509 -in https-server.pem  -text -noout
+#
+# To add the cert into your application do this:
+#       openssl x509 -in https-server.pem  -C -noout
+#
+
+import socket
+from BaseHTTPServer import HTTPServer
+from SimpleHTTPServer import SimpleHTTPRequestHandler
+import ssl
+
+PORT = 4443
+
+class HTTPServerV6(HTTPServer):
+    address_family = socket.AF_INET6
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    length = 0
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.send_header('Content-Length', str(self.length))
+        self.end_headers()
+
+    def do_POST(self):
+        payload = "<html><p>Done</p></html>"
+        self.length = len(payload)
+        self._set_headers()
+        self.wfile.write(payload)
+
+def main():
+    httpd = HTTPServerV6(("", PORT), RequestHandler)
+    print "Serving at port", PORT
+    httpd.socket = ssl.wrap_socket(httpd.socket,
+                                   certfile='/net-tools/https-server.pem',
+                                   server_side=True)
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Zephyr http-client sample needs http(s) server to run
against to.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>