### PR TITLE
docker: Add HTTP get script and curl to the container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,6 +63,10 @@ RUN git clone https://git.code.sf.net/p/linuxptp/code linuxptp && \
 
 COPY gptp.cfg /etc/
 
+# Run curl to get data from dumb_http_server_mt network sample
+RUN apt update && apt install curl netcat -y
+COPY http-get-file-test.sh /usr/local/bin
+
 WORKDIR /net-tools
 
 # We do not run any command automatically but let the test script run

--- a/docker/http-get-file-test.sh
+++ b/docker/http-get-file-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Simple TCP tester that queries a large HTTP file and checks whether it
+# contains the expected data. The network sample to respond these queries is
+# samples/net/sockets/dumb_http_srv_mt. With this sample we are not testing
+# HTTP because this sample does not implement HTTP server but always returns
+# a static file.
+
+SERVER=192.0.2.1
+PORT=8080
+
+# The file we are expecting to receive is found in
+# samples/net/sockets/dumb_http_server_mt/src/response_100k.html.bin
+EXPECTED_FILE_SIZE=108222
+EXPECTED_FILE_MD5SUM=d969441601d473db911f28dae62101b7
+
+# If user gives a parameter to this function, it is used as a count how
+# many times to ask the data. The value 0 (default) loops forever.
+
+if [ -z "$1" ]; then
+    COUNT=0
+else
+    COUNT=$1
+fi
+
+DOWNLOAD_FILE=/tmp/`basename $0`.$$
+MD5SUM_FILE=${DOWNLOAD_FILE}.md5sum
+
+echo "$EXPECTED_FILE_MD5SUM $DOWNLOAD_FILE" > $MD5SUM_FILE
+
+CONNECTION_TIMEOUT=0
+STATUS=0
+STOPPED=0
+trap ctrl_c INT TERM
+
+ctrl_c() {
+    STOPPED=1
+}
+
+while [ $STOPPED -eq 0 ]; do
+    curl http://${SERVER}:${PORT} --max-time 5 --output $DOWNLOAD_FILE
+    STATUS=$?
+    if [ $STATUS -ne 0 ]; then
+	if [ $STATUS -eq 28 ]; then
+	    CONNECTION_TIMEOUT=1
+	fi
+
+	break
+    fi
+
+    FILE_SIZE=$(stat --printf=%s $DOWNLOAD_FILE)
+    if [ $FILE_SIZE -ne $EXPECTED_FILE_SIZE ]; then
+        echo "Wrong size, expected $EXPECTED_FILE_SIZE, got $FILE_SIZE"
+        STATUS=1
+	break
+    fi
+
+    md5sum --status -c $MD5SUM_FILE
+    STATUS=$?
+    if [ $STATUS -ne 0 ]; then
+	break
+    fi
+
+    if [ $COUNT -eq 0 ]; then
+	continue
+    fi
+
+    COUNT=$(expr $COUNT - 1)
+    if [ $COUNT -eq 0 ]; then
+	break
+    fi
+done
+
+rm -f $DOWNLOAD_FILE $MD5SUM_FILE
+
+if [ $CONNECTION_TIMEOUT -eq 0 ]; then
+    if [ $STATUS -eq 0 ]; then
+	printf "OK\r\n\r\n" | nc $SERVER $PORT
+    else
+	printf "FAIL\r\n\r\n" | nc $SERVER $PORT
+    fi
+fi
+
+exit $STATUS


### PR DESCRIPTION
Zephyr dumb_http_server_mt network sample needs a HTTP client
script to do queries.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>