### PR TITLE
docker: Add tcpdump to image for CoAP server testing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,8 @@ FROM gcc
 RUN apt update && apt install -y \
     dante-server \
     curl \
-    netcat
+    netcat \
+    tcpdump
 
 # We need the net-tools project as it contains helper apps needed
 # in testing.


### PR DESCRIPTION
The /net-tools/libcoap/examples/etsi_coaptest.sh needs tcpdump
to run.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>