### PR TITLE
docker: Allow user to specify the bind address

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,7 @@ COPY mosquitto.conf mosquitto-tls.conf /usr/local/etc/mosquitto/
 # The http-get-file-test.sh is used for testing TCP with dumb-http-server-mt
 # network sample.
 COPY http-server.py https-server.py http-get-file-test.sh /usr/local/bin/
+COPY http-get-file-test.sh /usr/local/bin/https-get-file-test.sh
 
 # Dante is SOCKS proxy. The gptp.conf is conf file for linuxptp.
 COPY danted.conf gptp.cfg /etc/

--- a/docker/http-get-file-test.sh
+++ b/docker/http-get-file-test.sh
@@ -9,6 +9,14 @@
 # HTTP because this sample does not implement HTTP server but always returns
 # a static file.
 
+if [ `basename $0` == "https-get-file-test.sh" ]; then
+    PROTO=https
+    EXTRA_OPTS="--insecure"
+else
+    PROTO=http
+    EXTRA_OPTS=""
+fi
+
 SERVER=192.0.2.1
 PORT=8080
 
@@ -41,7 +49,7 @@ ctrl_c() {
 }
 
 while [ $STOPPED -eq 0 ]; do
-    curl http://${SERVER}:${PORT} --max-time 5 --output $DOWNLOAD_FILE
+    curl ${PROTO}://${SERVER}:${PORT} $EXTRA_OPTS --max-time 5 --output $DOWNLOAD_FILE
     STATUS=$?
     if [ $STATUS -ne 0 ]; then
 	if [ $STATUS -eq 28 ]; then
@@ -78,9 +86,9 @@ rm -f $DOWNLOAD_FILE $MD5SUM_FILE
 
 if [ $CONNECTION_TIMEOUT -eq 0 ]; then
     if [ $STATUS -eq 0 ]; then
-	printf "OK\r\n\r\n" | nc $SERVER $PORT
+	curl -d "OK" -X POST $EXTRA_OPTS ${PROTO}://${SERVER}:${PORT}
     else
-	printf "FAIL\r\n\r\n" | nc $SERVER $PORT
+	curl -d "FAIL" -X POST $EXTRA_OPTS ${PROTO}://${SERVER}:${PORT}
     fi
 fi
 

--- a/docker/https-server.py
+++ b/docker/https-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # HTTPS server test application.
 #
@@ -15,16 +15,16 @@
 #
 
 import socket
-from BaseHTTPServer import HTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 import ssl
+import sys
 
 PORT = 4443
 
 class HTTPServerV6(HTTPServer):
     address_family = socket.AF_INET6
 
-class RequestHandler(SimpleHTTPRequestHandler):
+class RequestHandler(BaseHTTPRequestHandler):
     length = 0
 
     def _set_headers(self):
@@ -39,13 +39,20 @@ class RequestHandler(SimpleHTTPRequestHandler):
         self._set_headers()
         self.wfile.write(payload)
 
-def main():
-    httpd = HTTPServerV6(("", PORT), RequestHandler)
-    print "Serving at port", PORT
-    httpd.socket = ssl.wrap_socket(httpd.socket,
-                                   certfile='/net-tools/https-server.pem',
-                                   server_side=True)
+def main(address):
+    if ':' in address:
+        httpd = HTTPServerV6((address, PORT), RequestHandler)
+    else:
+        httpd = HTTPServer((address, PORT), RequestHandler)
+
+    print("Serving at port", PORT)
+    httpd.socket = ssl.wrap_socket (httpd.socket,
+                                    certfile='/net-tools/https-server.pem',
+                                    server_side=True)
     httpd.serve_forever()
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) > 1:
+        main(sys.argv[1])
+    else:
+        main('::')


### PR DESCRIPTION
Let the user to decide what listening address to bind.
Convert the script to python3.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>