### PR TITLE
net-setup: Add configuration file for IP tunneling

### DIFF
--- a/net-setup.sh
+++ b/net-setup.sh
@@ -130,6 +130,10 @@ fi
 if [ "$ACTION" != start ]; then
     ip link set $IFACE down
 
+    if [ -f "$CONF_FILE".stop ]; then
+	. "$CONF_FILE".stop $IFACE
+    fi
+
     echo "Removing $IFACE"
     ip tuntap del $IFACE mode tap
 fi

--- a/zeth-tunnel.conf
+++ b/zeth-tunnel.conf
@@ -1,0 +1,62 @@
+# Configuration file for setting IP addresses for tunneling network interfaces
+
+INTERFACE="$1"
+
+HWADDR="00:00:5e:00:53:ff"
+
+# Read the "TUNNEL_VxVy" as "Vx over Vy"
+TUNNEL_V4V4=${INTERFACE}-ipip
+TUNNEL_V4V6=${INTERFACE}-ipip6
+TUNNEL_V6V4=${INTERFACE}-ip6ip
+TUNNEL_V6V6=${INTERFACE}-ip6ip6
+
+PREFIX_1_IPV6="2001:db8:100"
+PREFIXLEN_1_IPV6="64"
+PREFIX_2_IPV6="2001:db8:200"
+PREFIXLEN_2_IPV6="64"
+
+# From RFC 5737
+PREFIX_1_IPV4="198.51.100"
+PREFIXLEN_1_IPV4="24"
+PREFIX_2_IPV4="203.0.113"
+PREFIXLEN_2_IPV4="24"
+
+# Remote and local addresses for the tunnel.
+IPV6_ADDR_REMOTE="2001:db8::1"
+IPV6_ADDR_LOCAL="2001:db8::2"
+IPV6_ROUTE_LOCAL="2001:db8::/64"
+IPV4_ADDR_REMOTE="192.0.2.1"
+IPV4_ADDR_LOCAL="192.0.2.2"
+IPV4_ROUTE_LOCAL="192.0.2.0/24"
+
+ip link set dev ${INTERFACE} up
+ip link set dev ${INTERFACE} address ${HWADDR}
+
+ip -6 address add ${IPV6_ADDR_LOCAL} dev ${INTERFACE}
+ip -6 route add ${IPV6_ROUTE_LOCAL} dev ${INTERFACE}
+ip address add ${IPV4_ADDR_LOCAL} dev ${INTERFACE}
+ip route add ${IPV4_ROUTE_LOCAL} dev ${INTERFACE}
+
+ip tunnel add ${TUNNEL_V6V4} mode sit local ${IPV4_ADDR_LOCAL} \
+	remote ${IPV4_ADDR_REMOTE} dev ${INTERFACE}
+ip tunnel add ${TUNNEL_V4V6} mode ipip6 local ${IPV6_ADDR_LOCAL} \
+	remote ${IPV6_ADDR_REMOTE} dev ${INTERFACE}
+ip tunnel add ${TUNNEL_V4V4} mode ipip local ${IPV4_ADDR_LOCAL} \
+	remote ${IPV4_ADDR_REMOTE} dev ${INTERFACE}
+ip tunnel add ${TUNNEL_V6V6} mode ip6ip6 local ${IPV6_ADDR_LOCAL} \
+	remote ${IPV6_ADDR_REMOTE} dev ${INTERFACE}
+
+ip link set ${TUNNEL_V4V4} up
+ip link set ${TUNNEL_V6V4} up
+ip link set ${TUNNEL_V4V6} up
+ip link set ${TUNNEL_V6V6} up
+
+ip addr add ${PREFIX_1_IPV4}.2/${PREFIXLEN_1_IPV4} dev ${TUNNEL_V4V4}
+ip addr add ${PREFIX_2_IPV4}.2/${PREFIXLEN_2_IPV4} dev ${TUNNEL_V4V6}
+ip route add ${PREFIX_1_IPV4}/${PREFIXLEN_1_IPV4} dev ${TUNNEL_V4V4}
+ip route add ${PREFIX_2_IPV4}/${PREFIXLEN_2_IPV4} dev ${TUNNEL_V4V6}
+
+ip -6 addr add ${PREFIX_1_IPV6}::2/${PREFIXLEN_1_IPV6} dev ${TUNNEL_V6V6}
+ip -6 addr add ${PREFIX_2_IPV6}::2/${PREFIXLEN_2_IPV6} dev ${TUNNEL_V6V4}
+ip -6 route add ${PREFIX_1_IPV6}::/${PREFIXLEN_1_IPV6} dev ${TUNNEL_V6V6}
+ip -6 route add ${PREFIX_2_IPV6}::/${PREFIXLEN_2_IPV6} dev ${TUNNEL_V6V4}

--- a/zeth-tunnel.conf.stop
+++ b/zeth-tunnel.conf.stop
@@ -1,0 +1,19 @@
+# Configuration file for setting IP addresses for tunneling network interfaces
+
+INTERFACE="$1"
+
+# Read the "TUNNEL_VxVy" as "Vx over Vy"
+TUNNEL_V4V4=${INTERFACE}-ipip
+TUNNEL_V6V6=${INTERFACE}-ip6ip6
+TUNNEL_V6V4=${INTERFACE}-ip6ip
+TUNNEL_V4V6=${INTERFACE}-ipip6
+
+ip link set ${TUNNEL_V4V4} down
+ip link set ${TUNNEL_V4V6} down
+ip link set ${TUNNEL_V6V6} down
+ip link set ${TUNNEL_V6V4} down
+
+ip tunnel del ${TUNNEL_V4V4}
+ip tunnel del ${TUNNEL_V6V6}
+ip tunnel del ${TUNNEL_V6V4}
+ip tunnel del ${TUNNEL_V4V6}


### PR DESCRIPTION
Add a config file that can setup IP tunneling.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>

This is related to https://github.com/zephyrproject-rtos/zephyr/pull/32840