### PR TITLE
tunnel: Adjusting the zeth-tunnel.conf file

### DIFF
--- a/zeth-tunnel.conf
+++ b/zeth-tunnel.conf
@@ -37,13 +37,20 @@ ip -6 route add ${IPV6_ROUTE_LOCAL} dev ${INTERFACE}
 ip address add ${IPV4_ADDR_LOCAL} dev ${INTERFACE}
 ip route add ${IPV4_ROUTE_LOCAL} dev ${INTERFACE}
 
-ip tunnel add ${TUNNEL_V6V4} mode sit local ${IPV4_ADDR_LOCAL} \
+ip tunnel add name ${TUNNEL_V4V4} mode ipip local ${IPV4_ADDR_LOCAL} \
 	remote ${IPV4_ADDR_REMOTE} dev ${INTERFACE}
-ip tunnel add ${TUNNEL_V4V6} mode ipip6 local ${IPV6_ADDR_LOCAL} \
+
+ip tunnel add name ${TUNNEL_V6V4} mode sit local ${IPV4_ADDR_LOCAL} \
+	remote ${IPV4_ADDR_REMOTE} dev ${INTERFACE}
+
+ip tunnel add name ${TUNNEL_V4V6} mode ipip6 local ${IPV6_ADDR_LOCAL} \
 	remote ${IPV6_ADDR_REMOTE} dev ${INTERFACE}
-ip tunnel add ${TUNNEL_V4V4} mode ipip local ${IPV4_ADDR_LOCAL} \
-	remote ${IPV4_ADDR_REMOTE} dev ${INTERFACE}
-ip tunnel add ${TUNNEL_V6V6} mode ip6ip6 local ${IPV6_ADDR_LOCAL} \
+
+# Create separate ip6ip6 link, otherwise the tunnel creation can fail
+# (because default interface ip6tnl0 might already exist)
+ip link add name ${TUNNEL_V6V6} type ip6tnl local ${IPV6_ADDR_LOCAL} \
+	remote ${IPV6_ADDR_REMOTE} mode ip6ip6
+ip tunnel add name ${TUNNEL_V6V6} mode ip6ip6 local ${IPV6_ADDR_LOCAL} \
 	remote ${IPV6_ADDR_REMOTE} dev ${INTERFACE}
 
 ip link set ${TUNNEL_V4V4} up


### PR DESCRIPTION
The ip6ip6 tunnel was not created properly. Adjust also the
commands so that tunnels are set as expected.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>