### PR TITLE
net-setup: zeth.conf.stop script

### DIFF
--- a/zeth.conf.stop
+++ b/zeth.conf.stop
@@ -1,0 +1,5 @@
+# Configuration file for removing a network interface.
+
+INTERFACE="$1"
+
+ip link delete $INTERFACE


### PR DESCRIPTION
Removes the zeth network interface when executed.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>