### PR TITLE
zephyr-websocket-server.py: use tabs for indentation

### DIFF
--- a/zephyr-websocket-server.py
+++ b/zephyr-websocket-server.py
@@ -19,7 +19,7 @@ def client_left(client, server):
 # Called when a client sends a message
 def message_received(client, server, message):
 	print("Client(%d) sent[%d]" % (client['id'], len(message)))
-        server.send_message(client, message)
+	server.send_message(client, message)
 
 PORT=9001
 server = WebsocketServer(PORT, host="192.0.2.2", loglevel=logging.INFO)


### PR DESCRIPTION
Otherwise python fails with following error message:

  File "zephyr-websocket-server.py", line 22
    server.send_message(client, message)
TabError: inconsistent use of tabs and spaces in indentation