### PR TITLE
Add Leshan demo server and fix docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
 # Create Docker image that can be used for testing Zephyr network
 # sample applications.
 
-FROM gcc
+FROM gcc:bookworm
 
 # Get all the extra app we need in the container
 RUN apt update && apt install -y \
     dante-server \
     curl \
-    netcat \
+    netcat-traditional \
     tcpdump
 
 # We need the net-tools project as it contains helper apps needed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@ RUN apt update && apt install -y \
     dante-server \
     curl \
     netcat-traditional \
-    tcpdump
+    tcpdump \
+    default-jre-headless
 
 # We need the net-tools project as it contains helper apps needed
 # in testing.
@@ -67,6 +68,11 @@ COPY http-get-file-test.sh /usr/local/bin/https-get-file-test.sh
 
 # Dante is SOCKS proxy. The gptp.conf is conf file for linuxptp.
 COPY danted.conf gptp.cfg /etc/
+
+# Leshan demo server
+RUN cd /net-tools && \
+    wget 'https://ci.eclipse.org/leshan/job/leshan/lastSuccessfulBuild/artifact/leshan-server-demo.jar' && \
+    wget 'https://ci.eclipse.org/leshan/job/leshan/lastSuccessfulBuild/artifact/leshan-bsserver-demo.jar'
 
 WORKDIR /net-tools
 

--- a/start-leshan.sh
+++ b/start-leshan.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -eu
+
+# Download Leshan if needed
+if [ ! -f leshan-server-demo.jar ]; then
+        wget https://ci.eclipse.org/leshan/job/leshan/lastSuccessfulBuild/artifact/leshan-server-demo.jar
+fi
+
+if [ ! -f leshan-bsserver-demo.jar ]; then
+	wget 'https://ci.eclipse.org/leshan/job/leshan/lastSuccessfulBuild/artifact/leshan-bsserver-demo.jar'
+fi
+
+mkdir -p log
+
+start-stop-daemon --make-pidfile --pidfile log/leshan.pid --chdir $(pwd) --background --start \
+        --startas /bin/bash -- -c "exec java -jar ./leshan-server-demo.jar -wp 8080 -vv --models-folder objects >log/leshan.log 2>&1"
+
+start-stop-daemon --make-pidfile --pidfile log/leshan_bs.pid --chdir $(pwd) --background --start \
+        --startas /bin/bash -- -c "exec java -jar ./leshan-bsserver-demo.jar -lp=5783 -slp=5784 -wp 8081 -vv >log/leshan_bs.log 2>&1"

--- a/stop-leshan.sh
+++ b/stop-leshan.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -eu
+
+start-stop-daemon --remove-pidfile --pidfile log/leshan.pid --stop
+start-stop-daemon --remove-pidfile --pidfile log/leshan_bs.pid --stop


### PR DESCRIPTION
Two changes in this PR:

* Latest GCC image was update to Debian Bookworm and that caused `apt install` to fail as one of the packet changed its name.
  Changed the GCC to point to a named bookworm tag, so it does not automatically update to next debian release.

* Add Leshan demo server and Leshan demo bootstrap servers that we can test against.

I'm going to follow up the Zephyr repository with `docker-tests.sh` that uses this.
