### PR TITLE
net-setup: Add stop script for docker network

### DIFF
--- a/README.docker
+++ b/README.docker
@@ -7,7 +7,7 @@
 
 * Setup network interfaces, IP addresses and routes
 
-	./net-setup.sh --config docker.conf
+	sudo ./net-setup.sh --config docker.conf start
 
 * Run Docker image
 
@@ -49,6 +49,6 @@
 	docker container exec net-tools /net-tools/echo-client 192.0.2.1
 	docker container exec net-tools /net-tools/echo-client -t 192.0.2.1
 
-* Remove the 'net-tools0' docker network:
+* Remove the network setup:
 
-	docker network rm net-tools0
+	sudo ./net-setup.sh --config docker.conf stop

--- a/docker.conf
+++ b/docker.conf
@@ -38,4 +38,5 @@ else
 			 (read br rest ; echo $br) )"
 fi
 
-echo $DOCKER_INTERFACE
+echo Created bridge: $DOCKER_INTERFACE
+echo Created docker net: $DOCKER_USER_INTERFACE

--- a/docker.conf.stop
+++ b/docker.conf.stop
@@ -1,0 +1,4 @@
+DOCKER_USER_INTERFACE=$(awk -F'=' '/DOCKER_USER_INTERFACE=/{print $2}' docker.conf)
+
+echo -n Remove docker net:
+docker network rm $DOCKER_USER_INTERFACE


### PR DESCRIPTION
As the docker network setup creates an interface
called net-tools0, we should equally remove that
when we stop the network.