### PR TITLE
net-setup: Remove NAT rule when stopping

### DIFF
--- a/nat.conf
+++ b/nat.conf
@@ -19,9 +19,8 @@ ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
 ip address add $IPV4_ADDR_1 dev $INTERFACE
 ip route add $IPV4_ROUTE_1 dev $INTERFACE > /dev/null 2>&1
 
-if ! iptables -t nat -C POSTROUTING -j MASQUERADE -s $IPV4_ROUTE_1; then
-	iptables -t nat -A POSTROUTING -j MASQUERADE -s $IPV4_ROUTE_1
-fi
+iptables -t nat -A POSTROUTING -j MASQUERADE -s $IPV4_ROUTE_1
+
 sysctl -w net.ipv4.ip_forward=1 
 iptables -P FORWARD ACCEPT
 

--- a/nat.conf.stop
+++ b/nat.conf.stop
@@ -1,4 +1,6 @@
 INTERFACE="$1"
+IPV4_ROUTE_1=$(awk -F'=' '/IPV4_ROUTE_1=/{gsub(/"/, "", $2);print $2}' nat.conf)
 
 kill $(cat /var/run/dnsmasq_zeth.pid)
 sysctl -w net.ipv4.ip_forward=0
+iptables -t nat -D POSTROUTING -j MASQUERADE -s $IPV4_ROUTE_1


### PR DESCRIPTION
One rule is added to iptables POSTROUTING table when nat.conf network is started.
This should be removed when we stop, otherwise it breaks same address used in docker.conf network setup.