### PR TITLE
docker: Use fixed milestone release for Leshan

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,8 +71,8 @@ COPY danted.conf gptp.cfg /etc/
 
 # Leshan demo server
 RUN cd /net-tools && \
-    wget 'https://ci.eclipse.org/leshan/job/leshan/lastSuccessfulBuild/artifact/leshan-server-demo.jar' && \
-    wget 'https://ci.eclipse.org/leshan/job/leshan/lastSuccessfulBuild/artifact/leshan-bsserver-demo.jar'
+    curl 'https://repo1.maven.org/maven2/org/eclipse/leshan/leshan-server-demo/2.0.0-M14/leshan-server-demo-2.0.0-M14-jar-with-dependencies.jar' -o leshan-server-demo.jar && \
+    curl 'https://repo1.maven.org/maven2/org/eclipse/leshan/leshan-bsserver-demo/2.0.0-M14/leshan-bsserver-demo-2.0.0-M14-jar-with-dependencies.jar' -o leshan-bsserver-demo.jar
 
 WORKDIR /net-tools
 


### PR DESCRIPTION
If our links would stay static, there is no easy way to update Leshan, as Docker may keep local caches.
Instead point to a fixed release URI, so when we update the URI, re-building the docker image would fetch a new Leshan.

There is no official release of Leshan yet, that would support what Zephyr LwM2M testing needs, M14 is the first milestone that has all that we require.