### PR TITLE
Online connectivity support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ COPY mosquitto.conf mosquitto-tls.conf /usr/local/etc/mosquitto/
 # network sample.
 # The syslog-receiver.py will test syslog-net sample
 COPY http-server.py https-server.py http-get-file-test.sh \
-     syslog-receiver.py /usr/local/bin/
+     syslog-receiver.py connectivity-check.sh /usr/local/bin/
 COPY http-get-file-test.sh /usr/local/bin/https-get-file-test.sh
 
 # Dante is SOCKS proxy. The gptp.conf is conf file for linuxptp.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,10 @@ RUN apt update && apt install -y \
     curl \
     netcat-traditional \
     tcpdump \
-    default-jre-headless
+    default-jre-headless \
+    dnsmasq \
+    iproute2 \
+    iputils-ping
 
 # We need the net-tools project as it contains helper apps needed
 # in testing.
@@ -73,6 +76,9 @@ COPY danted.conf gptp.cfg /etc/
 RUN cd /net-tools && \
     curl 'https://repo1.maven.org/maven2/org/eclipse/leshan/leshan-server-demo/2.0.0-M14/leshan-server-demo-2.0.0-M14-jar-with-dependencies.jar' -o leshan-server-demo.jar && \
     curl 'https://repo1.maven.org/maven2/org/eclipse/leshan/leshan-bsserver-demo/2.0.0-M14/leshan-bsserver-demo-2.0.0-M14-jar-with-dependencies.jar' -o leshan-bsserver-demo.jar
+
+# DNS resolver to test online connectivity checker
+COPY dnsmasq.conf /etc/
 
 WORKDIR /net-tools
 

--- a/docker/connectivity-check.sh
+++ b/docker/connectivity-check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start dnsmasq and http server and listen connections. This script is run
+# inside Docker container.
+
+dnsmasq -C /etc/dnsmasq.conf &
+/usr/local/bin/http-server.py

--- a/docker/connectivity-check.sh
+++ b/docker/connectivity-check.sh
@@ -7,4 +7,5 @@
 # inside Docker container.
 
 dnsmasq -C /etc/dnsmasq.conf &
-/usr/local/bin/http-server.py
+/usr/local/bin/http-server.py &
+/usr/local/bin/https-server.py

--- a/docker/http-server.py
+++ b/docker/http-server.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import socket
-from BaseHTTPServer import HTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 
 PORT = 8000
 
 class HTTPServerV6(HTTPServer):
     address_family = socket.AF_INET6
 
-class RequestHandler(SimpleHTTPRequestHandler):
+class RequestHandler(BaseHTTPRequestHandler):
     length = 0
 
     def _set_headers(self):
@@ -22,11 +21,17 @@ class RequestHandler(SimpleHTTPRequestHandler):
         payload = "<html><p>Done</p></html>"
         self.length = len(payload)
         self._set_headers()
-        self.wfile.write(payload)
+        self.wfile.write(payload.encode())
+
+    def do_GET(self):
+        payload = "<html><p>Done</p></html>"
+        self.length = len(payload)
+        self._set_headers()
+        self.wfile.write(payload.encode())
 
 def main():
     httpd = HTTPServerV6(("", PORT), RequestHandler)
-    print "Serving at port", PORT
+    print("Serving at port", PORT)
     httpd.serve_forever()
 
 if __name__ == '__main__':

--- a/docker/https-server.py
+++ b/docker/https-server.py
@@ -39,6 +39,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         self._set_headers()
         self.wfile.write(payload)
 
+    def do_GET(self):
+        payload = "<html><p>Done</p></html>"
+        self.length = len(payload)
+        self._set_headers()
+        self.wfile.write(payload.encode())
+
 def main(address):
     if ':' in address:
         httpd = HTTPServerV6((address, PORT), RequestHandler)


### PR DESCRIPTION
This adds dnsmasq and http-server to the Docker container so that the online connectivity check feature can be tested.
The connection manager online connectivity check can be found here https://github.com/zephyrproject-rtos/zephyr/pull/63531