### PR TITLE
docker: Add missing dnsmasq.conf file to docker directory

### DIFF
--- a/docker/dnsmasq.conf
+++ b/docker/dnsmasq.conf
@@ -1,0 +1,20 @@
+# dnsmasq for testing DNS and DHCPv4 with Docker
+
+interface=eth0
+
+# Do not use 53 (DNS) or 5353 (mDNS) ports in order not to have problems
+# in your local network.
+port=15353
+bind-interfaces
+no-resolv
+
+address=/4.zephyr.test/192.0.2.2
+address=/6.zephyr.test/2001:db8::2
+address=/online.zephyr.test/192.0.2.2
+address=/online.zephyr.test/2001:db8::2
+
+# Add zephyrtest to /etc/hosts for next cname to work
+cname=ztest,zephyrtest
+
+domain=zephyr.test
+dhcp-range=192.0.2.16,192.0.2.32,1h


### PR DESCRIPTION
The config file is needed by the dnsmasq process, it was not added to the repo so the docker build fails.