### PR TITLE
treewide: place net-tools inside tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 The comments and instructions below are for the new IP stack in Zephyr.
 
+In a Zephyr default setup, the network tools are pre-installed under the
+`tools` directory.
+
 Here are instructions how to communicate between Zephyr that is running
 inside QEMU, and host device that is running Linux.
 

--- a/loop-radvd.sh
+++ b/loop-radvd.sh
@@ -34,11 +34,11 @@ else
 fi
 
 if [ ! -f $CONF_FILE ]; then
-    if [ ! -f $ZEPHYR_BASE/../net-tools/$CONF_FILE ]; then
+    if [ ! -f $ZEPHYR_BASE/../tools/net-tools/$CONF_FILE ]; then
 	echo "Cannot find $CONF_FILE file."
 	exit 1
     fi
-    DIR=$ZEPHYR_BASE/../net-tools
+    DIR=$ZEPHYR_BASE/../tools/net-tools
 else
     DIR=.
 fi

--- a/loop-slip-tap.sh
+++ b/loop-slip-tap.sh
@@ -19,7 +19,7 @@
 
 tunslip_prog=""
 
-for tunslip in ./tunslip6 "${0%/*}/tunslip6"  $ZEPHYR_BASE/../net-tools/tunslip6
+for tunslip in ./tunslip6 "${0%/*}/tunslip6"  $ZEPHYR_BASE/../tools/net-tools/tunslip6
 do
     if [ -x "$tunslip" ]
     then

--- a/loop-slip.sh
+++ b/loop-slip.sh
@@ -18,11 +18,11 @@
 # to manually restart tunslip process that creates the tun0 device.
 
 if [ ! -f ./tunslip6 ]; then
-    if [ ! -f $ZEPHYR_BASE/../net-tools/tunslip6 ]; then
+    if [ ! -f $ZEPHYR_BASE/../tools/net-tools/tunslip6 ]; then
 	echo "Cannot find tunslip6 executable."
 	exit 1
     fi
-    DIR=$ZEPHYR_BASE/../net-tools
+    DIR=$ZEPHYR_BASE/../tools/net-tools
 else
     DIR=.
 fi

--- a/systemd/loop-slip-tap.service
+++ b/systemd/loop-slip-tap.service
@@ -4,8 +4,8 @@ Requires=loop-socat.service
 After=loop-socat.service
 
 [Service]
-Environment=ZEPHYR_BASE=/home/zephyr/z
-ExecStart=/home/zephyr/net-tools/loop-slip-tap.sh -v5
+Environment=ZEPHYR_BASE=/home/zephyrproject/
+ExecStart=/home/zephyrproject/tools/net-tools/loop-slip-tap.sh -v5
 
 [Install]
 Wants=loop-socat.service


### PR DESCRIPTION
Updates ocurrences depending on $ZEPHYR_BASE to refer to the correct placement of net-tools under tools.