### PR TITLE
net-setup: Add config for setting up multiple network interfaces

### DIFF
--- a/net-setup.sh
+++ b/net-setup.sh
@@ -63,6 +63,11 @@ fi
 
 IFACE=zeth
 
+# The counter variable is passed to configuration script where
+# it can be used for example to create multiple network interfaces etc.
+# The -t option can be used to set the variable.
+COUNTER=1
+
 # Default config file setups default connectivity IP addresses
 CONF_FILE=./zeth.conf
 
@@ -75,6 +80,10 @@ do
 	    ;;
 	--iface|-i)
 	    IFACE="$2"
+	    shift 2
+	    ;;
+	--times|-t)
+	    COUNTER="$2"
 	    shift 2
 	    ;;
 	--help|-h)

--- a/zeth-multiface.conf
+++ b/zeth-multiface.conf
@@ -1,0 +1,56 @@
+# Configuration file for setting IP addresses for multiple network interface.
+
+INTERFACE_PREFIX="$1"
+
+HWADDR_PREFIX="00:00:5e:00:53:"
+
+IPV6_ADDR_PREFIX0="2001:db8::"
+IPV6_ROUTE0="2001:db8::/64"
+
+IPV6_ADDR_PREFIX1="2001:db8:2::"
+IPV6_ROUTE1="2001:db8:2::/64"
+
+IPV4_ADDR_PREFIX0="192.0.2."
+IPV4_ADDR_PREFIX1="198.51.100."
+
+INTERFACE0=${INTERFACE_PREFIX}
+INTERFACE1=`echo ${INTERFACE_PREFIX} | sed "s/0/1/g"`
+
+IPV4_ROUTE0="${IPV4_ADDR_PREFIX0}0/24"
+IPV4_ROUTE1="${IPV4_ADDR_PREFIX1}0/24"
+
+# The zeth0 is already created by net-setup script so avoid
+# doing it twice.
+ip link set dev ${INTERFACE0} up
+ip link set dev ${INTERFACE0} address ${HWADDR_PREFIX}0
+ip -6 address add ${IPV6_ADDR_PREFIX0}2 dev $INTERFACE0 nodad
+ip -6 route add $IPV6_ROUTE0 dev $INTERFACE0
+ip address add ${IPV4_ADDR_PREFIX0}2 dev $INTERFACE0
+ip route add $IPV4_ROUTE0 dev $INTERFACE0 2>&1
+
+COUNT=${COUNTER:-2}
+
+INTERFACE_TMPL=`echo ${INTERFACE_PREFIX} | sed "s/0//g"`
+
+for ((i = 1; i < $COUNT; i++ )); {
+	iface_idx=$i
+	INTERFACE=${INTERFACE_TMPL}${iface_idx}
+
+	ip tuntap add ${INTERFACE} mode tap
+	ip link set dev ${INTERFACE} up
+
+	# If there are config options then try to apply them.
+	# TODO: this should be changed to use a yaml file or similar.
+	VAR_CHECK="INTERFACE${iface_idx}"
+	if [ -n "${!VAR_CHECK}" ]; then
+	    ip link set dev ${INTERFACE} address ${HWADDR_PREFIX}${iface_idx}
+	    VAR=IPV6_ADDR_PREFIX${iface_idx}
+	    ip -6 address add ${!VAR}${iface_idx} dev ${INTERFACE} nodad
+	    VAR=IPV6_ROUTE${iface_idx}
+	    ip -6 route add ${!VAR} dev ${INTERFACE}
+	    VAR=IPV4_ADDR_PREFIX${iface_idx}
+	    ip address add ${!VAR}${iface_idx} dev ${INTERFACE}
+	    VAR=IPV4_ROUTE${iface_idx}
+	    ip route add ${!VAR} dev ${INTERFACE} 2>&1
+	fi
+}

--- a/zeth-multiface.conf.stop
+++ b/zeth-multiface.conf.stop
@@ -1,0 +1,13 @@
+# Configuration file for setting IP addresses for multiple network interface.
+
+COUNT=${COUNTER:-2}
+INTERFACE_PREFIX="$1"
+
+INTERFACE_TMPL=`echo ${INTERFACE_PREFIX} | sed "s/0//g"`
+
+for ((i = 1; i < $COUNT; i++ )); {
+	iface_idx=$i
+	INTERFACE=${INTERFACE_TMPL}${iface_idx}
+
+	ip tuntap del $INTERFACE mode tap
+}


### PR DESCRIPTION
This is mainly useful for testing Ethernet bridging when using native-sim board.