### PR TITLE
net-setup: Kill dockers using our network when stopping

### DIFF
--- a/docker.conf.stop
+++ b/docker.conf.stop
@@ -1,4 +1,16 @@
 DOCKER_USER_INTERFACE=$(awk -F'=' '/DOCKER_USER_INTERFACE=/{print $2}' docker.conf)
 
+# Don't execute anything, if network does not exist anymore
+if ! docker network inspect $DOCKER_USER_INTERFACE 2>&1 >/dev/null; then
+	return 1
+fi
+
+echo Stop containers using docker net
+FMT="{{range .Containers}}{{println .Name}}{{end}}"
+for cont in $(docker network inspect $DOCKER_USER_INTERFACE --format "$FMT")
+do
+	docker kill $cont
+done
+
 echo -n Remove docker net:
 docker network rm $DOCKER_USER_INTERFACE


### PR DESCRIPTION
If some docker instance is still using net-tools0 network, our docker.conf.stop was failing to remove the network, and therefore next time the startup was not working either.

kill all docker instances that still use the net-tools0 when we stop. This allows network to to be removed.