### PR TITLE
can-setup: rename default configuration file

### DIFF
--- a/can-setup.sh
+++ b/can-setup.sh
@@ -18,7 +18,7 @@ usage() {
     cat <<EOF
 $0 [--config|-c <file>] [--iface|-i <interface>] [start|up] [stop|down]
 
-If no parameters are given, then "zcan0" network interface and "zcan0.conf"
+If no parameters are given, then "zcan0" network interface and "vcan.conf"
 configuration file are used. The script waits until user presses CTRL-c
 and then removes the canbus network interface.
 
@@ -63,7 +63,7 @@ fi
 IFACE=zcan0
 
 # Default config file setups default connectivity
-CONF_FILE=./zcan0.conf
+CONF_FILE=./vcan.conf
 
 while [ $# -gt 0 ]
 do

--- a/vcan.conf
+++ b/vcan.conf
@@ -1,4 +1,4 @@
-# Configuration file for setting a CANBUS interface.
+# Configuration file for creating a virtual SocketCAN interface.
 
 INTERFACE="$1"
 

--- a/vcan.conf.stop
+++ b/vcan.conf.stop
@@ -1,4 +1,4 @@
-# Configuration file for removing a network interface.
+# Configuration file for removing a virtual SocketCAN interface.
 
 INTERFACE="$1"
 


### PR DESCRIPTION
Rename the default configuration file used by can-setup.sh from zcan0.conf to vcan.conf, as it can be used to manage any virtual SocketCAN interface by specifying the --iface parameter.

My apologies for not realizing this on the first review. Having integrated the use of this script in a couple of downstream workflows now made me realize the full potential.