### PR TITLE
net-setup: Fix invoking script without arguments

### DIFF
--- a/net-setup.sh
+++ b/net-setup.sh
@@ -51,7 +51,7 @@ EOF
     exit
 }
 
-if [ "$1" = "-h" -o "$1" = "--help" ]; then
+if [ "${1:-}" = "-h" -o "${1:-}" = "--help" ]; then
     usage
 fi
 


### PR DESCRIPTION
I was following [Zephyr guide](https://docs.zephyrproject.org/latest/connectivity/networking/native_sim_setup.html#basic-setup) to setup networking for echo server and found out that `./net-setup.sh` called without arguments cause an error:

```
$ ./net-setup.sh
./net-setup.sh: line 54: $1: unbound variable
 ```

Fixed it by expanding '$1' to empty string in early 'if' statement to prevent "$1: unbound variable" errors.