### PR TITLE
net-setup: Remove the -eu option from bash

### DIFF
--- a/net-setup.sh
+++ b/net-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash
 #
 # Copyright (c) 2018 Intel Corporation
 #
@@ -51,7 +51,7 @@ EOF
     exit
 }
 
-if [ "${1:-}" = "-h" -o "${1:-}" = "--help" ]; then
+if [ "$1" = "-h" -o "$1" = "--help" ]; then
     usage
 fi
 


### PR DESCRIPTION
The previous fix for "unbound variable" did not work as expected as the script run to exit instead of waiting ctrl-c to be pressed. Remove the -eu when starting bash to solve the issue.