### PR TITLE
Fix shebang errors

### DIFF
--- a/libcoap/autogen.sh
+++ b/libcoap/autogen.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh -e
+#!/usr/bin/env sh
+set -e
 
 # uncomment the set command for debugging
 #set -x

--- a/start-leshan.sh
+++ b/start-leshan.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh -eu
+#!/usr/bin/env sh
+set -eu
 
 # Download Leshan if needed
 if [ ! -f leshan-server-demo.jar ]; then

--- a/stop-leshan.sh
+++ b/stop-leshan.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh -eu
+#!/usr/bin/env sh
+set -eu
 
 start-stop-daemon --remove-pidfile --pidfile log/leshan.pid --stop
 start-stop-daemon --remove-pidfile --pidfile log/leshan_bs.pid --stop


### PR DESCRIPTION
Enable options via set command to prevent errors` /usr/bin/env: 'sh -e': No such file or directory ` and `/usr/bin/env: 'sh -eu': No such file or directory` on some systems.