### PR TITLE
ttcn3: Add protocol conformance suites for Zephyr networking

### DIFF
--- a/docker/Dockerfile.ttcn3
+++ b/docker/Dockerfile.ttcn3
@@ -1,0 +1,46 @@
+# Adds a TTCN-3 toolchain to the net-tools image, for the protocol conformance
+# suites under ttcn3/.
+#
+# Build the net-tools image first, then this one:
+#
+#   docker build -t net-tools .
+#   docker build -t net-tools-ttcn3 -f Dockerfile.ttcn3 .
+#
+# Titan is built from source rather than taken from the distribution, because
+# the packaged version trails the protocol modules the suites build against.
+# The build takes a while; the layer is cached, so it happens once.
+#
+# The build is serial on purpose. Parts of the runtime include headers that
+# another part generates, and a parallel make loses that race.
+
+FROM net-tools
+
+ARG TITAN_VERSION=11.2.1
+
+RUN apt update && apt install -y \
+    bison \
+    expect \
+    flex \
+    libedit-dev \
+    libncurses-dev \
+    libssl-dev \
+    libxml2-dev \
+    xutils-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV TTCN3_DIR=/opt/titan
+ENV PATH=/opt/titan/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/titan/lib
+
+RUN git clone https://gitlab.eclipse.org/eclipse/titan/titan.core.git /titan.core && \
+    cd /titan.core && \
+    git checkout "tags/$TITAN_VERSION" && \
+    printf '%s\n' \
+        'TTCN3_DIR := /opt/titan' \
+        'XMLDIR := /usr' \
+        'OPENSSL_DIR := /usr' \
+        'JNI := no' \
+        'GEN_PDF := no' \
+        > Makefile.personal && \
+    make install && \
+    rm -rf /titan.core

--- a/ttcn3/.gitignore
+++ b/ttcn3/.gitignore
@@ -1,0 +1,8 @@
+# Clones made by fetch-modules.sh.
+modules/
+
+# Per suite build trees made by build.sh.
+suites/*/build/
+
+# Logs left behind by a run.
+*.log

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -4,97 +4,14 @@ Test suites written in [TTCN-3](https://www.ttcn-3.org/) and built with
 [Eclipse Titan](https://projects.eclipse.org/projects/tools.titan), run against
 a Zephyr instance over a real network interface.
 
-These are black box tests. A suite speaks the protocol to Zephyr the way any
-other host on the link would, and checks what comes back against the standard.
-Nothing is compiled into Zephyr for them, and no Zephyr side test hooks are
-needed: the system under test is an ordinary sample application.
+**The documentation for these suites lives in the Zephyr tree**, at
+[Protocol conformance testing with TTCN-3](https://docs.zephyrproject.org/latest/connectivity/networking/conformance/index.html).
+It covers what each suite tests, how to install Titan, how to set up the network
+interfaces, how to run everything through Twister, and how to add a suite. Start
+there.
 
-| Suite | System under test | What it covers |
-|---|---|---|
-| `mdns` | `tests/net/conformance/mdns` | Name resolution over IPv4 and IPv6, record shape, silence for names the responder does not own |
-| `dns` | `tests/net/conformance/dns` | Query shape, identifier unpredictability, and what the resolver does with unanswered, forged and malformed answers |
-| `coap` | `tests/net/conformance/coap` | The ETSI derived CoAP core test cases, run against a server exposing /test |
-| `dhcpv4` | `tests/net/conformance/dhcpv4` | Discover shape, retransmission, and the offer, request and acknowledge exchange |
-| `arp` | `tests/net/conformance/arp` | Answering for its own address, staying quiet about others, and asking before it sends |
-| `tcp` | `tests/net/conformance/tcp` | Handshake and sequence accounting, initial sequence numbers, data, close, reset, malformed segments, sequence wrap |
-
-## Getting a Titan
-
-Either install the packaged one:
-
-```
-sudo apt install --no-install-recommends eclipse-titan
-export TTCN3_DIR=/usr
-```
-
-or build a current one from source, following `docker/Dockerfile.ttcn3`, which
-is what continuous integration uses. The packaged version trails the protocol
-modules, so prefer the source build if a suite fails to compile.
-
-## Running a suite
-
-Fetch the third party modules the suites build against. This clones them into
-`modules/` at the commits pinned in `modules.txt`, and is safe to re-run:
-
-```
-./fetch-modules.sh
-```
-
-Bring up the network interface that faces Zephyr, and start the sample:
-
-```
-sudo ../net-setup.sh --config ../zeth.conf start
-west build -b native_sim -d build/mdns "$ZEPHYR_BASE/samples/net/mdns_responder"
-./build/mdns/zephyr/zephyr.exe &
-```
-
-Then build and run the suite:
-
-```
-./build.sh mdns
-cd suites/mdns/build && ./mdns ../mdns.cfg
-```
-
-A suite that has to bind a privileged port, or read frames off the link, says
-`PRIVILEGED=yes` in its `build.conf` and has to be run as root. `dhcpv4` does
-because DHCP is defined on ports 67 and 68 and there is no way to move it;
-`arp` and `tcp` do because reading frames needs a packet socket.
-
-A suite that works below the IP layer also says `L2=yes`, and uses a second
-interface described by `../zeth-l2.conf`. That interface is given no IP
-address on purpose. Linux answers address resolution and neighbour discovery
-for any address it holds on any interface unless told otherwise, and an answer
-from the host would be indistinguishable from an answer from Zephyr:
-
-```
-sudo ../net-setup.sh --config ../zeth-l2.conf --iface zethL2 start
-```
-
-A suite whose test cases create parallel test components cannot be run as one
-process. Those say `MODE=parallel` in a `build.conf`, and are run through the
-main controller instead, which needs `expect` installed:
-
-```
-./build.sh coap
-cd suites/coap/build && ttcn3_start ./coap ../coap.cfg
-```
-
-The last line of the output is the verdict:
-
-```
-Verdict statistics: 0 none (0.00 %), 7 pass (100.00 %), 0 inconc (0.00 %), 0 fail (0.00 %), 0 error (0.00 %).
-Test execution summary: 7 test cases were executed. Overall verdict: pass
-```
-
-To run one test case instead of the whole suite, name it on the command line:
-
-```
-./mdns ../mdns.cfg MDNS_Suite.tc_a_query
-```
-
-Addresses, the interface name and the timeouts all come from
-`[MODULE_PARAMETERS]` in the suite's `.cfg`, so a run can be moved onto a
-different link without touching the suite.
+What follows is the part that is specific to this repository: how the build
+works and how the third party modules are managed.
 
 ## Layout
 
@@ -107,52 +24,55 @@ build.sh         builds one suite
 suites/<name>/   the suite, its sources.txt and its .cfg
 ```
 
-`build.sh` links the suite sources, the shared layer and the module sources
-named in the suite's `sources.txt` into `suites/<name>/build`, and builds there.
-The flat layout matters: the makefile Titan generates builds a dependency rule
-with `sed` using the target stem as the pattern, which breaks as soon as a
-source is named through a path containing a slash.
+## Building a suite
 
-## Third party modules
+`./fetch-modules.sh` once, then:
 
-The suites build against protocol modules and test ports from the Eclipse Titan
-project, which are separate repositories under
-`https://gitlab.eclipse.org/eclipse/titan/`. They are not vendored here; they
-are cloned on demand and pinned by commit so that a suite which passes today
-still builds tomorrow.
+```
+./build.sh <suite> [make arguments]
+```
 
-One test port is written here rather than taken from them. The Titan project
-publishes `LANL2asp` for reading and writing ethernet frames, but it captures
-with libpcap and opens the handle with a zero read timeout, which on Linux
-asks the kernel to wait indefinitely for a capture block to fill. On a link as
-quiet as a test link the frames never reach the test, and there is no parameter
-to change it. `common/Ethernet_PT.cc` reads a packet socket instead.
+Anything after the suite name is passed to `make`, so `./build.sh mdns -j8` and
+`./build.sh mdns clean` both work. `TTCN3_DIR` has to point at a Titan
+installation; both the packaged layout (`include/titan`, `lib/titan`) and a
+source build (`include`, `lib`) are detected.
 
-They are distributed under the Eclipse Public License 2.0, whereas everything
-written here is Apache 2.0. Both are approved by the Open Source Initiative,
-which is what Zephyr asks of tooling that never becomes part of a Zephyr
-image; see `doc/contribute/external.rst` in the Zephyr tree.
+The result is `suites/<suite>/build/<suite>`. To run it, put Titan's library
+directory on `LD_LIBRARY_PATH` and give it the configuration file:
 
-To move a pin, change the commit in `modules.txt` and re-run
-`./fetch-modules.sh`.
+```
+cd suites/mdns/build && ./mdns ../mdns.cfg
+```
 
-## Adding a suite
+A single test case is run by naming it, which is the quick loop while writing
+one:
 
-1. Create `suites/<name>/` with the TTCN-3 source, a `sources.txt` naming the
-   module sources it needs, and a `<name>.cfg`. A suite that only runs test
-   cases from a third party module needs no source of its own; see `coap`.
-2. Take addresses and timeouts from `common/Zephyr_SUT.ttcn` rather than
-   writing them into the suite.
-3. If the suite needs a module that is not in `modules.txt` yet, add it there
-   with a pinned commit.
-4. If its test cases create parallel test components, or it has to bind a
-   privileged port, add a `build.conf` saying `MODE=parallel` or
-   `PRIVILEGED=yes`.
-5. Add a row to the table at the top of this file.
+```
+./mdns ../mdns.cfg MDNS_Suite.tc_a_query
+```
 
-## Building in the container
+`build.sh` wipes the build directory and rebuilds it flat, symlinking the suite
+sources, the shared layer and the module sources named in `common/sources.txt`
+and the suite's own `sources.txt` side by side. The flat layout matters: the
+makefile Titan generates builds a dependency rule with `sed` using the target
+stem as the pattern, which breaks as soon as a source is named through a path
+containing a slash.
 
-The image `docker/Dockerfile.ttcn3` builds carries a current Titan. Give it your
+### build.conf
+
+A suite may carry a `build.conf`, which is both sourced as a shell fragment by
+`build.sh` and read by the Zephyr side harness:
+
+| Setting | Effect |
+|---|---|
+| `MODE=parallel` | Test cases create parallel test components, so the suite is built for and run through Titan's main controller. Default is `MODE=single`. |
+| `PRIVILEGED=yes` | The suite binds a privileged port or opens a packet socket, so it has to be run as root. |
+| `L2=yes` | The suite works below the IP layer and wants the address-less `zethL2` interface. |
+| `LIBS=...` | Extra libraries to link against, beyond what Titan itself needs. |
+
+### Building in the container
+
+`docker/Dockerfile.ttcn3` builds an image carrying a current Titan. Give it your
 own user id when building a suite through a bind mount, or it leaves artifacts
 behind that you cannot delete:
 
@@ -161,44 +81,34 @@ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/ttcn3" -w /ttcn3 \
        net-tools-ttcn3 ./build.sh mdns
 ```
 
-## The older TCP suite
+## Third party modules
 
-Intel published a TTCN-3 TCP suite in the `net-test-suites` repository, for the
-TCP rewrite. Its scenarios informed what the `tcp` suite covers, but none of its
-code is used, and it is not a starting point to return to.
+The suites build against protocol modules and test ports from the Eclipse Titan
+project, which are separate repositories under
+`https://gitlab.eclipse.org/eclipse/titan/`. They are not vendored here; they
+are cloned on demand and pinned by commit so that a suite which passes today
+still builds tomorrow. `modules.txt` holds one `<repository> <commit>` line per
+module. To move a pin, change the commit there and re-run `./fetch-modules.sh`.
 
-Forty-one of its forty-three test cases drive Zephyr through a JSON control
-channel rather than over the wire, and its central assertion compares the
-stack's internal TCP state name against an expected one. That tests the
-implementation rather than the protocol, breaks whenever the internals are
-renamed, and needs `CONFIG_NET_TEST_PROTOCOL`, which deliberately turns off
-initial sequence number randomisation — so it exercises a TCP that is not the
-one that ships. What it had that is worth keeping is the list of scenarios.
+One test port is written here rather than taken from them. The Titan project
+publishes `LANL2asp` for reading and writing ethernet frames, but it captures
+with libpcap and opens the handle with a zero read timeout, which on Linux
+asks the kernel to wait indefinitely for a capture block to fill. On a link as
+quiet as a test link the frames never reach the test, and there is no parameter
+to change it. `common/Ethernet_PT.cc` reads a packet socket instead.
 
-## Known gaps and divergences
+The modules are distributed under the Eclipse Public License 2.0, whereas
+everything written here is Apache 2.0. Both are approved by the Open Source
+Initiative, which is what Zephyr asks of tooling that never becomes part of a
+Zephyr image; see `doc/contribute/external.rst` in the Zephyr tree.
 
-Where a suite asserts behaviour that does not match the RFC, the assertion says
-so at the point it is made, so that the divergence is recorded rather than
-frozen in silently.
+## Configuration files
 
-Three findings that were recorded here have since been fixed and are now
-asserted by the suites instead: the mDNS responder answers a legacy unicast
-query conventionally, the DNS resolver renews its source port, and the DHCPv4
-client keeps one transaction identifier per transaction.
+Addresses, the interface name and the timeouts all come from
+`[MODULE_PARAMETERS]` in the suite's `.cfg`, so a run can be moved onto a
+different link without touching the suite. A MAC address there is twelve
+hexadecimal digits with no separators, and `tsp_tester_mac` has to match the
+`source_address` given to the ethernet test port in the same file.
 
-**mDNS DNS-SD, RFC 6762 6.7.** The hostname side of the responder answers a
-legacy unicast query the way the RFC asks. The DNS-SD side does not: it builds
-its messages in `dns_sd.c`, which still sets the cache flush bit, uses its own
-long TTLs and echoes neither the identifier nor the question. Doing the same
-there means reworking the compression offsets those encoders compute from a
-fixed header size. No suite covers it yet either.
-
-**CoAP.** Two of the ETSI cases the suite publishes, `TD_COAP_BLOCK_01` and
-`TD_COAP_OBS_01`, are not run. They address a `/large` and an `/obs` resource,
-and the system under test provides only `/test`. Adding those resources, and
-the two cases with them, is the obvious next step for this suite.
-
-**DNS, RFC 5452 9.2.** The resolver renews its source port before a query to a
-server with nothing outstanding, which with the default of one query at a time
-means every query. Queries that overlap on one server still share a port, so
-the `dns` suite's check would not catch a regression in that case.
+Each suite logs to its build directory under the name set by `LogFile`, as
+`<suite>-<component>.<seq>.log`.

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -16,6 +16,7 @@ needed: the system under test is an ordinary sample application.
 | `coap` | `tests/net/conformance/coap` | The ETSI derived CoAP core test cases, run against a server exposing /test |
 | `dhcpv4` | `tests/net/conformance/dhcpv4` | Discover shape, retransmission, and the offer, request and acknowledge exchange |
 | `arp` | `tests/net/conformance/arp` | Answering for its own address, staying quiet about others, and asking before it sends |
+| `tcp` | `tests/net/conformance/tcp` | Handshake and sequence accounting, initial sequence numbers, data, close, reset, malformed segments, sequence wrap |
 
 ## Getting a Titan
 
@@ -57,7 +58,7 @@ cd suites/mdns/build && ./mdns ../mdns.cfg
 A suite that has to bind a privileged port, or read frames off the link, says
 `PRIVILEGED=yes` in its `build.conf` and has to be run as root. `dhcpv4` does
 because DHCP is defined on ports 67 and 68 and there is no way to move it;
-`arp` does because reading frames needs a packet socket.
+`arp` and `tcp` do because reading frames needs a packet socket.
 
 A suite that works below the IP layer also says `L2=yes`, and uses a second
 interface described by `../zeth-l2.conf`. That interface is given no IP
@@ -159,6 +160,20 @@ behind that you cannot delete:
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/ttcn3" -w /ttcn3 \
        net-tools-ttcn3 ./build.sh mdns
 ```
+
+## The older TCP suite
+
+Intel published a TTCN-3 TCP suite in the `net-test-suites` repository, for the
+TCP rewrite. Its scenarios informed what the `tcp` suite covers, but none of its
+code is used, and it is not a starting point to return to.
+
+Forty-one of its forty-three test cases drive Zephyr through a JSON control
+channel rather than over the wire, and its central assertion compares the
+stack's internal TCP state name against an expected one. That tests the
+implementation rather than the protocol, breaks whenever the internals are
+renamed, and needs `CONFIG_NET_TEST_PROTOCOL`, which deliberately turns off
+initial sequence number randomisation — so it exercises a TCP that is not the
+one that ships. What it had that is worth keeping is the list of scenarios.
 
 ## Known gaps and divergences
 

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -1,0 +1,120 @@
+# TTCN-3 protocol conformance suites for Zephyr
+
+Test suites written in [TTCN-3](https://www.ttcn-3.org/) and built with
+[Eclipse Titan](https://projects.eclipse.org/projects/tools.titan), run against
+a Zephyr instance over a real network interface.
+
+These are black box tests. A suite speaks the protocol to Zephyr the way any
+other host on the link would, and checks what comes back against the standard.
+Nothing is compiled into Zephyr for them, and no Zephyr side test hooks are
+needed: the system under test is an ordinary sample application.
+
+| Suite | System under test | What it covers |
+|---|---|---|
+| `mdns` | `samples/net/mdns_responder` | Name resolution over IPv4 and IPv6, record shape, silence for names the responder does not own |
+
+## Getting a Titan
+
+Either install the packaged one:
+
+```
+sudo apt install --no-install-recommends eclipse-titan
+export TTCN3_DIR=/usr
+```
+
+or build a current one from source, following `docker/Dockerfile.ttcn3`, which
+is what continuous integration uses. The packaged version trails the protocol
+modules, so prefer the source build if a suite fails to compile.
+
+## Running a suite
+
+Fetch the third party modules the suites build against. This clones them into
+`modules/` at the commits pinned in `modules.txt`, and is safe to re-run:
+
+```
+./fetch-modules.sh
+```
+
+Bring up the network interface that faces Zephyr, and start the sample:
+
+```
+sudo ../net-setup.sh --config ../zeth.conf start
+west build -b native_sim -d build/mdns "$ZEPHYR_BASE/samples/net/mdns_responder"
+./build/mdns/zephyr/zephyr.exe &
+```
+
+Then build and run the suite:
+
+```
+./build.sh mdns
+cd suites/mdns/build && ./mdns ../mdns.cfg
+```
+
+The last line of the output is the verdict:
+
+```
+Verdict statistics: 0 none (0.00 %), 7 pass (100.00 %), 0 inconc (0.00 %), 0 fail (0.00 %), 0 error (0.00 %).
+Test execution summary: 7 test cases were executed. Overall verdict: pass
+```
+
+To run one test case instead of the whole suite, name it on the command line:
+
+```
+./mdns ../mdns.cfg MDNS_Suite.tc_a_query
+```
+
+Addresses, the interface name and the timeouts all come from
+`[MODULE_PARAMETERS]` in the suite's `.cfg`, so a run can be moved onto a
+different link without touching the suite.
+
+## Layout
+
+```
+common/          TTCN-3 shared by every suite
+modules/         third party modules, cloned by fetch-modules.sh, not in git
+modules.txt      which third party modules, and at which commit
+fetch-modules.sh clones them
+build.sh         builds one suite
+suites/<name>/   the suite, its sources.txt and its .cfg
+```
+
+`build.sh` links the suite sources, the shared layer and the module sources
+named in the suite's `sources.txt` into `suites/<name>/build`, and builds there.
+The flat layout matters: the makefile Titan generates builds a dependency rule
+with `sed` using the target stem as the pattern, which breaks as soon as a
+source is named through a path containing a slash.
+
+## Third party modules
+
+The suites build against protocol modules and test ports from the Eclipse Titan
+project, which are separate repositories under
+`https://gitlab.eclipse.org/eclipse/titan/`. They are not vendored here; they
+are cloned on demand and pinned by commit so that a suite which passes today
+still builds tomorrow.
+
+They are distributed under the Eclipse Public License 2.0, whereas everything
+written here is Apache 2.0. Both are approved by the Open Source Initiative,
+which is what Zephyr asks of tooling that never becomes part of a Zephyr
+image; see `doc/contribute/external.rst` in the Zephyr tree.
+
+To move a pin, change the commit in `modules.txt` and re-run
+`./fetch-modules.sh`.
+
+## Adding a suite
+
+1. Create `suites/<name>/` with the TTCN-3 source, a `sources.txt` naming the
+   module sources it needs, and a `<name>.cfg`.
+2. Take addresses and timeouts from `common/Zephyr_SUT.ttcn` rather than
+   writing them into the suite.
+3. If the suite needs a module that is not in `modules.txt` yet, add it there
+   with a pinned commit.
+4. Add a row to the table at the top of this file.
+
+## Known divergences from the standard
+
+Where a suite asserts behaviour that does not match the RFC, the assertion says
+so at the point it is made. Today that is RFC 6762 6.7 in the `mdns` suite: the
+responder does not distinguish a legacy unicast query, so its answers to one
+carry identifier zero, no question section, the cache flush bit set and the
+full TTL. Answers to a real mDNS resolver, which queries from port 5353, are
+not affected.

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -15,6 +15,7 @@ needed: the system under test is an ordinary sample application.
 | `dns` | `tests/net/conformance/dns` | Query shape, identifier unpredictability, and what the resolver does with unanswered, forged and malformed answers |
 | `coap` | `tests/net/conformance/coap` | The ETSI derived CoAP core test cases, run against a server exposing /test |
 | `dhcpv4` | `tests/net/conformance/dhcpv4` | Discover shape, retransmission, and the offer, request and acknowledge exchange |
+| `arp` | `tests/net/conformance/arp` | Answering for its own address, staying quiet about others, and asking before it sends |
 
 ## Getting a Titan
 
@@ -53,9 +54,20 @@ Then build and run the suite:
 cd suites/mdns/build && ./mdns ../mdns.cfg
 ```
 
-A suite that has to bind a privileged port says `PRIVILEGED=yes` in its
-`build.conf` and has to be run as root. Only `dhcpv4` does: DHCP is defined on
-ports 67 and 68 and there is no way to move it.
+A suite that has to bind a privileged port, or read frames off the link, says
+`PRIVILEGED=yes` in its `build.conf` and has to be run as root. `dhcpv4` does
+because DHCP is defined on ports 67 and 68 and there is no way to move it;
+`arp` does because reading frames needs a packet socket.
+
+A suite that works below the IP layer also says `L2=yes`, and uses a second
+interface described by `../zeth-l2.conf`. That interface is given no IP
+address on purpose. Linux answers address resolution and neighbour discovery
+for any address it holds on any interface unless told otherwise, and an answer
+from the host would be indistinguishable from an answer from Zephyr:
+
+```
+sudo ../net-setup.sh --config ../zeth-l2.conf --iface zethL2 start
+```
 
 A suite whose test cases create parallel test components cannot be run as one
 process. Those say `MODE=parallel` in a `build.conf`, and are run through the
@@ -86,7 +98,7 @@ different link without touching the suite.
 ## Layout
 
 ```
-common/          TTCN-3 shared by every suite
+common/          TTCN-3 shared by every suite, and the ethernet test port
 modules/         third party modules, cloned by fetch-modules.sh, not in git
 modules.txt      which third party modules, and at which commit
 fetch-modules.sh clones them
@@ -107,6 +119,13 @@ project, which are separate repositories under
 `https://gitlab.eclipse.org/eclipse/titan/`. They are not vendored here; they
 are cloned on demand and pinned by commit so that a suite which passes today
 still builds tomorrow.
+
+One test port is written here rather than taken from them. The Titan project
+publishes `LANL2asp` for reading and writing ethernet frames, but it captures
+with libpcap and opens the handle with a zero read timeout, which on Linux
+asks the kernel to wait indefinitely for a capture block to fill. On a link as
+quiet as a test link the frames never reach the test, and there is no parameter
+to change it. `common/Ethernet_PT.cc` reads a packet socket instead.
 
 They are distributed under the Eclipse Public License 2.0, whereas everything
 written here is Apache 2.0. Both are approved by the Open Source Initiative,

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -14,6 +14,7 @@ needed: the system under test is an ordinary sample application.
 | `mdns` | `tests/net/conformance/mdns` | Name resolution over IPv4 and IPv6, record shape, silence for names the responder does not own |
 | `dns` | `tests/net/conformance/dns` | Query shape, identifier unpredictability, and what the resolver does with unanswered, forged and malformed answers |
 | `coap` | `tests/net/conformance/coap` | The ETSI derived CoAP core test cases, run against a server exposing /test |
+| `dhcpv4` | `tests/net/conformance/dhcpv4` | Discover shape, retransmission, and the offer, request and acknowledge exchange |
 
 ## Getting a Titan
 
@@ -51,6 +52,10 @@ Then build and run the suite:
 ./build.sh mdns
 cd suites/mdns/build && ./mdns ../mdns.cfg
 ```
+
+A suite that has to bind a privileged port says `PRIVILEGED=yes` in its
+`build.conf` and has to be run as root. Only `dhcpv4` does: DHCP is defined on
+ports 67 and 68 and there is no way to move it.
 
 A suite whose test cases create parallel test components cannot be run as one
 process. Those say `MODE=parallel` in a `build.conf`, and are run through the
@@ -120,8 +125,9 @@ To move a pin, change the commit in `modules.txt` and re-run
    writing them into the suite.
 3. If the suite needs a module that is not in `modules.txt` yet, add it there
    with a pinned commit.
-4. If its test cases create parallel test components, add a `build.conf`
-   saying `MODE=parallel`.
+4. If its test cases create parallel test components, or it has to bind a
+   privileged port, add a `build.conf` saying `MODE=parallel` or
+   `PRIVILEGED=yes`.
 5. Add a row to the table at the top of this file.
 
 ## Building in the container
@@ -152,6 +158,11 @@ resolver, which queries from port 5353, are not affected.
 `TD_COAP_OBS_01`, are not run. They address a `/large` and an `/obs` resource,
 and the system under test provides only `/test`. Adding those resources, and
 the two cases with them, is the obvious next step for this suite.
+
+**DHCPv4, RFC 2131 4.1.** A client is to use one transaction identifier for
+every message of a transaction. The client counts it up by one on each
+retransmission of a discover instead, which both invites a server to treat the
+retransmissions as separate clients and makes the identifier guessable.
 
 **DNS, RFC 5452 9.2.** The resolver varies the query identifier, which the
 `dns` suite checks, but keeps one socket per server, so its source port is

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -11,7 +11,8 @@ needed: the system under test is an ordinary sample application.
 
 | Suite | System under test | What it covers |
 |---|---|---|
-| `mdns` | `samples/net/mdns_responder` | Name resolution over IPv4 and IPv6, record shape, silence for names the responder does not own |
+| `mdns` | `tests/net/conformance/mdns` | Name resolution over IPv4 and IPv6, record shape, silence for names the responder does not own |
+| `dns` | `tests/net/conformance/dns` | Query shape, identifier unpredictability, and what the resolver does with unanswered, forged and malformed answers |
 
 ## Getting a Titan
 
@@ -110,11 +111,32 @@ To move a pin, change the commit in `modules.txt` and re-run
    with a pinned commit.
 4. Add a row to the table at the top of this file.
 
-## Known divergences from the standard
+## Building in the container
+
+The image `docker/Dockerfile.ttcn3` builds carries a current Titan. Give it your
+own user id when building a suite through a bind mount, or it leaves artifacts
+behind that you cannot delete:
+
+```
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/ttcn3" -w /ttcn3 \
+       net-tools-ttcn3 ./build.sh mdns
+```
+
+## Known gaps and divergences
 
 Where a suite asserts behaviour that does not match the RFC, the assertion says
-so at the point it is made. Today that is RFC 6762 6.7 in the `mdns` suite: the
-responder does not distinguish a legacy unicast query, so its answers to one
-carry identifier zero, no question section, the cache flush bit set and the
-full TTL. Answers to a real mDNS resolver, which queries from port 5353, are
-not affected.
+so at the point it is made, so that the divergence is recorded rather than
+frozen in silently.
+
+**mDNS, RFC 6762 6.7.** The responder does not distinguish a legacy unicast
+query, which is what a query from a port other than 5353 is. Its answers to one
+carry identifier zero, no question section, the cache flush bit set and the full
+TTL, where the RFC asks for the identifier echoed, the question repeated, the
+cache flush bit clear and the TTL capped at ten seconds. Answers to a real mDNS
+resolver, which queries from port 5353, are not affected.
+
+**DNS, RFC 5452 9.2.** The resolver varies the query identifier, which the
+`dns` suite checks, but keeps one socket per server, so its source port is
+fixed for as long as it runs. The RFC asks for both to vary, because the two
+together are what an off path attacker has to guess. There is no test case for
+this: one that asserted the current behaviour would fail the day it improved.

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -181,25 +181,24 @@ Where a suite asserts behaviour that does not match the RFC, the assertion says
 so at the point it is made, so that the divergence is recorded rather than
 frozen in silently.
 
-**mDNS, RFC 6762 6.7.** The responder does not distinguish a legacy unicast
-query, which is what a query from a port other than 5353 is. Its answers to one
-carry identifier zero, no question section, the cache flush bit set and the full
-TTL, where the RFC asks for the identifier echoed, the question repeated, the
-cache flush bit clear and the TTL capped at ten seconds. Answers to a real mDNS
-resolver, which queries from port 5353, are not affected.
+Three findings that were recorded here have since been fixed and are now
+asserted by the suites instead: the mDNS responder answers a legacy unicast
+query conventionally, the DNS resolver renews its source port, and the DHCPv4
+client keeps one transaction identifier per transaction.
+
+**mDNS DNS-SD, RFC 6762 6.7.** The hostname side of the responder answers a
+legacy unicast query the way the RFC asks. The DNS-SD side does not: it builds
+its messages in `dns_sd.c`, which still sets the cache flush bit, uses its own
+long TTLs and echoes neither the identifier nor the question. Doing the same
+there means reworking the compression offsets those encoders compute from a
+fixed header size. No suite covers it yet either.
 
 **CoAP.** Two of the ETSI cases the suite publishes, `TD_COAP_BLOCK_01` and
 `TD_COAP_OBS_01`, are not run. They address a `/large` and an `/obs` resource,
 and the system under test provides only `/test`. Adding those resources, and
 the two cases with them, is the obvious next step for this suite.
 
-**DHCPv4, RFC 2131 4.1.** A client is to use one transaction identifier for
-every message of a transaction. The client counts it up by one on each
-retransmission of a discover instead, which both invites a server to treat the
-retransmissions as separate clients and makes the identifier guessable.
-
-**DNS, RFC 5452 9.2.** The resolver varies the query identifier, which the
-`dns` suite checks, but keeps one socket per server, so its source port is
-fixed for as long as it runs. The RFC asks for both to vary, because the two
-together are what an off path attacker has to guess. There is no test case for
-this: one that asserted the current behaviour would fail the day it improved.
+**DNS, RFC 5452 9.2.** The resolver renews its source port before a query to a
+server with nothing outstanding, which with the default of one query at a time
+means every query. Queries that overlap on one server still share a port, so
+the `dns` suite's check would not catch a regression in that case.

--- a/ttcn3/README.md
+++ b/ttcn3/README.md
@@ -13,6 +13,7 @@ needed: the system under test is an ordinary sample application.
 |---|---|---|
 | `mdns` | `tests/net/conformance/mdns` | Name resolution over IPv4 and IPv6, record shape, silence for names the responder does not own |
 | `dns` | `tests/net/conformance/dns` | Query shape, identifier unpredictability, and what the resolver does with unanswered, forged and malformed answers |
+| `coap` | `tests/net/conformance/coap` | The ETSI derived CoAP core test cases, run against a server exposing /test |
 
 ## Getting a Titan
 
@@ -49,6 +50,15 @@ Then build and run the suite:
 ```
 ./build.sh mdns
 cd suites/mdns/build && ./mdns ../mdns.cfg
+```
+
+A suite whose test cases create parallel test components cannot be run as one
+process. Those say `MODE=parallel` in a `build.conf`, and are run through the
+main controller instead, which needs `expect` installed:
+
+```
+./build.sh coap
+cd suites/coap/build && ttcn3_start ./coap ../coap.cfg
 ```
 
 The last line of the output is the verdict:
@@ -104,12 +114,15 @@ To move a pin, change the commit in `modules.txt` and re-run
 ## Adding a suite
 
 1. Create `suites/<name>/` with the TTCN-3 source, a `sources.txt` naming the
-   module sources it needs, and a `<name>.cfg`.
+   module sources it needs, and a `<name>.cfg`. A suite that only runs test
+   cases from a third party module needs no source of its own; see `coap`.
 2. Take addresses and timeouts from `common/Zephyr_SUT.ttcn` rather than
    writing them into the suite.
 3. If the suite needs a module that is not in `modules.txt` yet, add it there
    with a pinned commit.
-4. Add a row to the table at the top of this file.
+4. If its test cases create parallel test components, add a `build.conf`
+   saying `MODE=parallel`.
+5. Add a row to the table at the top of this file.
 
 ## Building in the container
 
@@ -134,6 +147,11 @@ carry identifier zero, no question section, the cache flush bit set and the full
 TTL, where the RFC asks for the identifier echoed, the question repeated, the
 cache flush bit clear and the TTL capped at ten seconds. Answers to a real mDNS
 resolver, which queries from port 5353, are not affected.
+
+**CoAP.** Two of the ETSI cases the suite publishes, `TD_COAP_BLOCK_01` and
+`TD_COAP_OBS_01`, are not run. They address a `/large` and an `/obs` resource,
+and the system under test provides only `/test`. Adding those resources, and
+the two cases with them, is the obvious next step for this suite.
 
 **DNS, RFC 5452 9.2.** The resolver varies the query identifier, which the
 `dns` suite checks, but keeps one socket per server, so its source port is

--- a/ttcn3/build.sh
+++ b/ttcn3/build.sh
@@ -37,6 +37,20 @@ if [ ! -d "$suite_dir" ]; then
 	exit 1
 fi
 
+# Single mode by default: the executable is the whole test suite, and running
+# it needs neither a main controller nor expect. A suite whose test cases
+# create parallel test components cannot use it, and says so in build.conf.
+MODE=single
+if [ -f "$suite_dir/build.conf" ]; then
+	. "$suite_dir/build.conf"
+fi
+
+case "$MODE" in
+single)   mode_flag=-s ;;
+parallel) mode_flag= ;;
+*)        echo "unknown MODE '$MODE' in $suite_dir/build.conf" >&2; exit 1 ;;
+esac
+
 if [ -z "${TTCN3_DIR:-}" ]; then
 	echo "TTCN3_DIR is unset; point it at a Titan installation" >&2
 	exit 1
@@ -67,8 +81,12 @@ link_source()
 	ln -sf "$1" "$build_dir/$(basename "$1")"
 }
 
+# A suite that only runs test cases from a third party module has no sources
+# of its own, so an empty match here is not an error.
 for f in "$suite_dir"/*.ttcn "$here"/common/*.ttcn; do
-	link_source "$f"
+	if [ -f "$f" ]; then
+		link_source "$f"
+	fi
 done
 
 link_module_sources()
@@ -89,7 +107,7 @@ cd "$build_dir"
 names=$(ls ./*.ttcn ./*.cc ./*.hh 2>/dev/null | sed 's#^\./##')
 
 # shellcheck disable=SC2086
-"$TTCN3_DIR/bin/ttcn3_makefilegen" -g -s -f -e "$suite" $names
+"$TTCN3_DIR/bin/ttcn3_makefilegen" -g $mode_flag -f -e "$suite" $names
 
 make CPPFLAGS="-D\$(PLATFORM) -I. -I$titan_inc" \
      LDFLAGS="-L$titan_lib" \

--- a/ttcn3/build.sh
+++ b/ttcn3/build.sh
@@ -41,6 +41,9 @@ fi
 # it needs neither a main controller nor expect. A suite whose test cases
 # create parallel test components cannot use it, and says so in build.conf.
 MODE=single
+# Libraries a suite has to link against beyond what Titan itself needs. A test
+# port that talks to the network below the IP layer usually brings one.
+LIBS=
 if [ -f "$suite_dir/build.conf" ]; then
 	. "$suite_dir/build.conf"
 fi
@@ -83,7 +86,8 @@ link_source()
 
 # A suite that only runs test cases from a third party module has no sources
 # of its own, so an empty match here is not an error.
-for f in "$suite_dir"/*.ttcn "$here"/common/*.ttcn; do
+for f in "$suite_dir"/*.ttcn "$suite_dir"/*.cc "$suite_dir"/*.hh \
+	 "$here"/common/*.ttcn "$here"/common/*.cc "$here"/common/*.hh; do
 	if [ -f "$f" ]; then
 		link_source "$f"
 	fi
@@ -111,6 +115,7 @@ names=$(ls ./*.ttcn ./*.cc ./*.hh 2>/dev/null | sed 's#^\./##')
 
 make CPPFLAGS="-D\$(PLATFORM) -I. -I$titan_inc" \
      LDFLAGS="-L$titan_lib" \
+     LINUX_LIBS="-lxml2 $LIBS" \
      CXXFLAGS="-O2 -Wall -Wno-unused-variable -Wno-deprecated-declarations" \
      "$@"
 

--- a/ttcn3/build.sh
+++ b/ttcn3/build.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build one test suite. Usage: ./build.sh <suite-name> [make arguments]
+#
+# The suite is built as a single mode executable, so running it needs neither
+# the main controller nor expect:
+#
+#     cd suites/<name>/build && ./<name> ../<name>.cfg
+#
+# Everything is built in suites/<name>/build, where the suite sources and the
+# module sources it asks for are linked side by side. The flat layout is not
+# just tidiness: the makefile Titan generates builds a dependency rule with
+# sed and the stem as the pattern, which breaks as soon as a source is named
+# through a path with a slash in it.
+#
+# TTCN3_DIR must point at a Titan installation. Both layouts are handled: a
+# distribution package puts the headers in $TTCN3_DIR/include/titan, a source
+# install puts them in $TTCN3_DIR/include.
+
+set -eu
+
+suite=${1:-}
+if [ -z "$suite" ]; then
+	echo "usage: $0 <suite-name> [make arguments]" >&2
+	exit 1
+fi
+shift
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+suite_dir="$here/suites/$suite"
+build_dir="$suite_dir/build"
+
+if [ ! -d "$suite_dir" ]; then
+	echo "no such suite: $suite" >&2
+	exit 1
+fi
+
+if [ -z "${TTCN3_DIR:-}" ]; then
+	echo "TTCN3_DIR is unset; point it at a Titan installation" >&2
+	exit 1
+fi
+
+if [ ! -d "$here/modules" ]; then
+	echo "third party modules are missing; run ./fetch-modules.sh first" >&2
+	exit 1
+fi
+
+if [ -d "$TTCN3_DIR/include/titan" ]; then
+	titan_inc="$TTCN3_DIR/include/titan"
+	titan_lib="$TTCN3_DIR/lib/titan"
+else
+	titan_inc="$TTCN3_DIR/include"
+	titan_lib="$TTCN3_DIR/lib"
+fi
+
+rm -rf "$build_dir"
+mkdir -p "$build_dir"
+
+link_source()
+{
+	if [ ! -f "$1" ]; then
+		echo "missing source: $1" >&2
+		exit 1
+	fi
+	ln -sf "$1" "$build_dir/$(basename "$1")"
+}
+
+for f in "$suite_dir"/*.ttcn "$here"/common/*.ttcn; do
+	link_source "$f"
+done
+
+while read -r path; do
+	case "$path" in
+	''|\#*) continue ;;
+	esac
+	link_source "$here/modules/$path"
+done < "$suite_dir/sources.txt"
+
+cd "$build_dir"
+
+names=$(ls ./*.ttcn ./*.cc ./*.hh 2>/dev/null | sed 's#^\./##')
+
+# shellcheck disable=SC2086
+"$TTCN3_DIR/bin/ttcn3_makefilegen" -g -s -f -e "$suite" $names
+
+make CPPFLAGS="-D\$(PLATFORM) -I. -I$titan_inc" \
+     LDFLAGS="-L$titan_lib" \
+     CXXFLAGS="-O2 -Wall -Wno-unused-variable -Wno-deprecated-declarations" \
+     "$@"
+
+echo "Built $build_dir/$suite"

--- a/ttcn3/build.sh
+++ b/ttcn3/build.sh
@@ -71,12 +71,18 @@ for f in "$suite_dir"/*.ttcn "$here"/common/*.ttcn; do
 	link_source "$f"
 done
 
-while read -r path; do
-	case "$path" in
-	''|\#*) continue ;;
-	esac
-	link_source "$here/modules/$path"
-done < "$suite_dir/sources.txt"
+link_module_sources()
+{
+	while read -r path; do
+		case "$path" in
+		''|\#*) continue ;;
+		esac
+		link_source "$here/modules/$path"
+	done < "$1"
+}
+
+link_module_sources "$here/common/sources.txt"
+link_module_sources "$suite_dir/sources.txt"
 
 cd "$build_dir"
 

--- a/ttcn3/common/ARP_Types.ttcn
+++ b/ttcn3/common/ARP_Types.ttcn
@@ -11,6 +11,12 @@
  * that would have to be found first. Only the ethernet and IPv4 case is
  * described, which is the only case that occurs here: the lengths are fixed
  * rather than driving the field widths.
+ *
+ * This lives in the shared layer rather than in the suite that tests address
+ * resolution, because a suite working below IP has to answer it whether that
+ * is what it is testing or not. On a link with no address on the Linux side,
+ * nothing else will, and a system under test that cannot resolve the tester's
+ * address cannot send it anything.
  */
 module ARP_Types {
 

--- a/ttcn3/common/Ethernet_PT.cc
+++ b/ttcn3/common/Ethernet_PT.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* See Ethernet_Port.ttcn for what this is and why it exists. */
+
+#include "Ethernet_PT.hh"
+
+#include <errno.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netpacket/packet.h>
+#include <net/ethernet.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace Ethernet__Port {
+
+/* An ethernet header is fourteen octets: two addresses and a type. */
+static const size_t HEADER_LENGTH = 14;
+
+/* Enough for a frame with the largest ordinary payload, plus room for one
+ * that arrives longer than expected so that it can be seen to be wrong
+ * rather than silently truncated.
+ */
+static const size_t FRAME_BUFFER = 2048;
+
+Ethernet__PT::Ethernet__PT(const char *par_port_name)
+	: Ethernet__PT_BASE(par_port_name),
+	  interface_name(NULL),
+	  source_address_set(false),
+	  ethertype_filter(-1),
+	  socket_fd(-1),
+	  interface_index(-1)
+{
+	memset(source_address, 0, sizeof(source_address));
+}
+
+Ethernet__PT::~Ethernet__PT()
+{
+	Free(interface_name);
+}
+
+/* Read twelve or four hexadecimal digits into octets. Returns false on
+ * anything that is not the expected number of hexadecimal digits, so that a
+ * mistyped configuration is reported rather than quietly turned into zeroes.
+ */
+static bool parse_hex(const char *text, unsigned char *out, size_t octets)
+{
+	if (strlen(text) != octets * 2) {
+		return false;
+	}
+
+	for (size_t i = 0; i < octets; i++) {
+		unsigned int value;
+
+		if (sscanf(text + i * 2, "%2x", &value) != 1) {
+			return false;
+		}
+
+		out[i] = (unsigned char)value;
+	}
+
+	return true;
+}
+
+void Ethernet__PT::set_parameter(const char *parameter_name,
+				 const char *parameter_value)
+{
+	if (strcmp(parameter_name, "interface") == 0) {
+		Free(interface_name);
+		interface_name = mcopystr(parameter_value);
+	} else if (strcmp(parameter_name, "source_address") == 0) {
+		if (!parse_hex(parameter_value, source_address, 6)) {
+			TTCN_error("Ethernet__PT(%s): source_address has to be "
+				   "twelve hexadecimal digits, got '%s'",
+				   get_name(), parameter_value);
+		}
+		source_address_set = true;
+	} else if (strcmp(parameter_name, "ethertype") == 0) {
+		unsigned char type[2];
+
+		if (!parse_hex(parameter_value, type, 2)) {
+			TTCN_error("Ethernet__PT(%s): ethertype has to be four "
+				   "hexadecimal digits, got '%s'",
+				   get_name(), parameter_value);
+		}
+		ethertype_filter = (type[0] << 8) | type[1];
+	} else {
+		TTCN_warning("Ethernet__PT(%s): unknown parameter '%s'",
+			     get_name(), parameter_name);
+	}
+}
+
+void Ethernet__PT::user_map(const char *, Map_Params&)
+{
+	struct sockaddr_ll address;
+	struct packet_mreq membership;
+	struct ifreq request;
+
+	if (interface_name == NULL) {
+		TTCN_error("Ethernet__PT(%s): the interface parameter has to be set",
+			   get_name());
+	}
+
+	/* Every protocol, because the point of this port is to see whatever is
+	 * on the link rather than one thing on it.
+	 */
+	socket_fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+	if (socket_fd < 0) {
+		TTCN_error("Ethernet__PT(%s): cannot open a packet socket (%s). "
+			   "This port has to be run with enough privilege to do so.",
+			   get_name(), strerror(errno));
+	}
+
+	interface_index = if_nametoindex(interface_name);
+	if (interface_index == 0) {
+		close(socket_fd);
+		socket_fd = -1;
+		TTCN_error("Ethernet__PT(%s): there is no interface called '%s'",
+			   get_name(), interface_name);
+	}
+
+	memset(&address, 0, sizeof(address));
+	address.sll_family = AF_PACKET;
+	address.sll_protocol = htons(ETH_P_ALL);
+	address.sll_ifindex = interface_index;
+
+	if (bind(socket_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+		close(socket_fd);
+		socket_fd = -1;
+		TTCN_error("Ethernet__PT(%s): cannot bind to '%s' (%s)",
+			   get_name(), interface_name, strerror(errno));
+	}
+
+	/* Frames addressed to somebody else are part of what a test looks at,
+	 * so ask for them too.
+	 */
+	memset(&membership, 0, sizeof(membership));
+	membership.mr_ifindex = interface_index;
+	membership.mr_type = PACKET_MR_PROMISC;
+
+	if (setsockopt(socket_fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP,
+		       &membership, sizeof(membership)) < 0) {
+		TTCN_warning("Ethernet__PT(%s): cannot listen promiscuously on "
+			     "'%s' (%s)", get_name(), interface_name,
+			     strerror(errno));
+	}
+
+	/* Send from the interface's own address unless told otherwise, so that
+	 * a suite which does not care need not say anything.
+	 */
+	if (!source_address_set) {
+		memset(&request, 0, sizeof(request));
+		strncpy(request.ifr_name, interface_name, IFNAMSIZ - 1);
+
+		if (ioctl(socket_fd, SIOCGIFHWADDR, &request) < 0) {
+			TTCN_warning("Ethernet__PT(%s): cannot read the address of "
+				     "'%s' (%s), sending from all zeroes",
+				     get_name(), interface_name, strerror(errno));
+		} else {
+			memcpy(source_address, request.ifr_hwaddr.sa_data,
+			       sizeof(source_address));
+		}
+	}
+
+	Handler_Add_Fd_Read(socket_fd);
+}
+
+void Ethernet__PT::user_unmap(const char *, Map_Params&)
+{
+	if (socket_fd >= 0) {
+		Handler_Remove_Fd_Read(socket_fd);
+		close(socket_fd);
+		socket_fd = -1;
+	}
+}
+
+void Ethernet__PT::user_start()
+{
+}
+
+void Ethernet__PT::user_stop()
+{
+}
+
+void Ethernet__PT::outgoing_send(const Ethernet__Frame& send_par)
+{
+	unsigned char frame[FRAME_BUFFER];
+	struct sockaddr_ll address;
+	const OCTETSTRING& payload = send_par.payload();
+	int payload_length = payload.lengthof();
+	int type;
+
+	if ((size_t)payload_length + HEADER_LENGTH > sizeof(frame)) {
+		TTCN_error("Ethernet__PT(%s): the frame is %d octets, which is "
+			   "more than this port can send",
+			   get_name(), (int)(payload_length + HEADER_LENGTH));
+	}
+
+	memcpy(frame, (const unsigned char *)send_par.destination(), 6);
+
+	if (send_par.source().lengthof() == 6) {
+		memcpy(frame + 6, (const unsigned char *)send_par.source(), 6);
+	} else {
+		memcpy(frame + 6, source_address, 6);
+	}
+
+	memcpy(frame + 12, (const unsigned char *)send_par.etherType(), 2);
+	memcpy(frame + HEADER_LENGTH, (const unsigned char *)payload,
+	       payload_length);
+
+	type = (frame[12] << 8) | frame[13];
+
+	memset(&address, 0, sizeof(address));
+	address.sll_family = AF_PACKET;
+	address.sll_protocol = htons(type);
+	address.sll_ifindex = interface_index;
+	address.sll_halen = 6;
+	memcpy(address.sll_addr, frame, 6);
+
+	if (sendto(socket_fd, frame, HEADER_LENGTH + payload_length, 0,
+		   (struct sockaddr *)&address, sizeof(address)) < 0) {
+		TTCN_error("Ethernet__PT(%s): cannot send a frame (%s)",
+			   get_name(), strerror(errno));
+	}
+}
+
+void Ethernet__PT::Handle_Fd_Event_Readable(int fd)
+{
+	unsigned char frame[FRAME_BUFFER];
+	Ethernet__Frame message;
+	ssize_t length;
+	int type;
+
+	length = recv(fd, frame, sizeof(frame), 0);
+	if (length < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+			return;
+		}
+
+		TTCN_error("Ethernet__PT(%s): cannot read a frame (%s)",
+			   get_name(), strerror(errno));
+	}
+
+	if ((size_t)length < HEADER_LENGTH) {
+		TTCN_warning("Ethernet__PT(%s): a frame of %d octets is too short "
+			     "to hold a header, ignoring it",
+			     get_name(), (int)length);
+		return;
+	}
+
+	type = (frame[12] << 8) | frame[13];
+	if (ethertype_filter >= 0 && type != ethertype_filter) {
+		return;
+	}
+
+	message.destination() = OCTETSTRING(6, frame);
+	message.source() = OCTETSTRING(6, frame + 6);
+	message.etherType() = OCTETSTRING(2, frame + 12);
+	message.payload() = OCTETSTRING(length - HEADER_LENGTH,
+					frame + HEADER_LENGTH);
+
+	incoming_message(message);
+}
+
+void Ethernet__PT::Handle_Fd_Event_Error(int)
+{
+}
+
+void Ethernet__PT::Handle_Fd_Event_Writable(int)
+{
+}
+
+} /* end of namespace */

--- a/ttcn3/common/Ethernet_PT.hh
+++ b/ttcn3/common/Ethernet_PT.hh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef Ethernet__PT_HH
+#define Ethernet__PT_HH
+
+#include "Ethernet_Port.hh"
+
+namespace Ethernet__Port {
+
+class Ethernet__PT : public Ethernet__PT_BASE {
+public:
+	Ethernet__PT(const char *par_port_name = NULL);
+	~Ethernet__PT();
+
+	void set_parameter(const char *parameter_name, const char *parameter_value);
+
+private:
+	void Handle_Fd_Event_Error(int fd);
+	void Handle_Fd_Event_Writable(int fd);
+	void Handle_Fd_Event_Readable(int fd);
+
+protected:
+	void user_map(const char *system_port, Map_Params& params);
+	void user_unmap(const char *system_port, Map_Params& params);
+
+	void user_start();
+	void user_stop();
+
+	void outgoing_send(const Ethernet__Frame& send_par);
+
+private:
+	char *interface_name;
+	unsigned char source_address[6];
+	bool source_address_set;
+	int ethertype_filter;   /* -1 when every frame is handed up */
+	int socket_fd;
+	int interface_index;
+};
+
+} /* end of namespace */
+
+#endif

--- a/ttcn3/common/Ethernet_Port.ttcn
+++ b/ttcn3/common/Ethernet_Port.ttcn
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* A port that reads and writes ethernet frames on an interface.
+ *
+ * The Titan project publishes a test port for this, LANL2asp, but it captures
+ * with libpcap and opens the handle with a zero read timeout. On Linux that
+ * asks the kernel to wait indefinitely for a capture block to fill, so on a
+ * link as quiet as a test link the frames never reach the test. There is no
+ * parameter to change it, so this port reads a packet socket instead, which
+ * hands every frame up as it arrives.
+ *
+ * Test port parameters:
+ *
+ *   interface        name of the interface to read and write, required
+ *   source_address   hardware address to send from, twelve hexadecimal
+ *                    digits; defaults to the interface's own
+ *   ethertype        when set, only frames of this type are handed up, as
+ *                    four hexadecimal digits
+ *
+ * The port needs to be run with enough privilege to open a packet socket.
+ */
+module Ethernet_Port {
+
+import from General_Types all;
+
+type record Ethernet_Frame {
+	OCT6 destination,
+	OCT6 source,
+	OCT2 etherType,
+	octetstring payload
+}
+
+type port Ethernet_PT message {
+	inout Ethernet_Frame;
+}
+
+}

--- a/ttcn3/common/Zephyr_SUT.ttcn
+++ b/ttcn3/common/Zephyr_SUT.ttcn
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Settings shared by every suite: where the system under test is, where the
+ * tester is, and how long the tester waits. A suite should never hard code an
+ * address or a timeout; take it from here so that one configuration file can
+ * move a whole run onto a different link.
+ */
+module Zephyr_SUT {
+
+	/* Addresses of the Zephyr instance under test. These match the
+	 * defaults that the networking samples are configured with.
+	 */
+	modulepar charstring tsp_sut_ipv4 := "192.0.2.1";
+	modulepar charstring tsp_sut_ipv6 := "2001:db8::1";
+
+	/* Addresses of this tester, on the same link as the system under
+	 * test. On a Linux host these are the addresses of the zeth interface
+	 * that net-setup.sh creates.
+	 */
+	modulepar charstring tsp_tester_ipv4 := "192.0.2.2";
+	modulepar charstring tsp_tester_ipv6 := "2001:db8::2";
+
+	/* Interface on this host that faces the system under test. Sending to
+	 * a link local multicast group needs it: the address alone does not
+	 * say which link to send on, and binding a source address does not
+	 * settle it either.
+	 */
+	modulepar charstring tsp_tester_interface := "zeth";
+
+	/* Hostname the system under test answers to, without any domain. */
+	modulepar charstring tsp_sut_hostname := "zephyr";
+
+	/* How long to wait for an answer that is expected to arrive. */
+	modulepar float tsp_response_timeout := 5.0;
+
+	/* How long to wait before concluding that nothing is going to arrive.
+	 * Only ever spent by test cases that require silence, so keep it
+	 * short enough that a suite of them still finishes quickly.
+	 */
+	modulepar float tsp_silence_timeout := 2.0;
+}

--- a/ttcn3/common/Zephyr_Transport.ttcn
+++ b/ttcn3/common/Zephyr_Transport.ttcn
@@ -24,6 +24,8 @@ import from Zephyr_SUT all;
 type component Zephyr_Tester {
 	port IPL4asp_PT pt;
 	var ConnectionId v_connId := -1;
+	/* Only a suite that accepts connections uses this, see f_tcp_listen. */
+	var ConnectionId v_listenId := -1;
 	timer t_guard;
 }
 
@@ -80,6 +82,95 @@ function f_close() runs on Zephyr_Tester
 	unmap(mtc:pt, system:pt);
 }
 
+/* Listen for connections on TCP.
+ *
+ * The listening socket is not one anything is read from: a connection to it
+ * arrives as a port event carrying a connection of its own, and that is what
+ * the suite then talks over. f_tcp_accept waits for it.
+ */
+function f_tcp_listen(in charstring p_local_addr, in integer p_local_port)
+runs on Zephyr_Tester
+{
+	var Result v_res;
+
+	map(mtc:pt, system:pt);
+
+	v_res := f_IPL4_listen(pt, p_local_addr, p_local_port, { tcp := {} }, {});
+	if (not ispresent(v_res.connId)) {
+		setverdict(fail, "cannot listen on ", p_local_addr, ":",
+			   p_local_port);
+		stop;
+	}
+
+	v_listenId := v_res.connId;
+}
+
+/* Wait for something to connect, and make what connected the socket that
+ * f_send and f_receive use. Fails the test case and stops it if nothing
+ * connects, so callers can carry on as though it had.
+ */
+function f_tcp_accept(in float p_timeout := -1.0)
+runs on Zephyr_Tester return ConnectionId
+{
+	var ASP_Event v_event;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(ASP_Event:{ connOpened := ? }) -> value v_event {
+		t_guard.stop;
+		v_connId := v_event.connOpened.connId;
+	}
+	[] pt.receive(ASP_Event:?) {
+		/* Some other notification, a closed connection for instance. */
+		repeat;
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "nothing connected within ", v_timeout, "s");
+		stop;
+	}
+	}
+
+	return v_connId;
+}
+
+/* Close a connection and the socket that was listening for it. */
+function f_tcp_close() runs on Zephyr_Tester
+{
+	if (v_connId != -1) {
+		f_IPL4_close(pt, v_connId);
+		v_connId := -1;
+	}
+
+	if (v_listenId != -1) {
+		f_IPL4_close(pt, v_listenId);
+		v_listenId := -1;
+	}
+
+	unmap(mtc:pt, system:pt);
+}
+
+/* Send over a connection, which unlike a datagram needs no address. */
+function f_send(in octetstring p_msg, in ConnectionId p_connId := -1)
+runs on Zephyr_Tester
+{
+	var ConnectionId v_from := p_connId;
+
+	if (v_from == -1) {
+		v_from := v_connId;
+	}
+
+	pt.send(ASP_Send:{
+		connId := v_from,
+		proto := omit,
+		msg := p_msg
+	});
+}
+
 /* Send from the socket f_udp_listen opened, or from another one when a
  * connection id is given.
  */
@@ -119,6 +210,14 @@ function f_receive(in float p_timeout := -1.0) runs on Zephyr_Tester return ASP_
 	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
 		t_guard.stop;
 	}
+	[] pt.receive(ASP_Event:?) {
+		/* A notification rather than data: a connection opening or
+		 * closing under a suite that works over TCP. Left unmatched it
+		 * would sit at the head of the queue and hide everything after
+		 * it, so it is taken and dropped.
+		 */
+		repeat;
+	}
 	[] t_guard.timeout {
 		setverdict(fail, "nothing arrived within ", v_timeout, "s");
 		stop;
@@ -146,6 +245,10 @@ runs on Zephyr_Tester
 	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
 		t_guard.stop;
 		setverdict(fail, "answered when it should have stayed quiet: ", p_why);
+	}
+	[] pt.receive(ASP_Event:?) {
+		/* A notification is not an answer, see f_receive. */
+		repeat;
 	}
 	[] t_guard.timeout {
 		setverdict(pass);

--- a/ttcn3/common/Zephyr_Transport.ttcn
+++ b/ttcn3/common/Zephyr_Transport.ttcn
@@ -36,20 +36,38 @@ type component Zephyr_Tester {
  *
  * A local port of zero asks the system for a free one.
  */
-function f_udp_listen(in charstring p_local_addr, in integer p_local_port := 0)
+function f_udp_listen(in charstring p_local_addr, in integer p_local_port := 0,
+		      in boolean p_reuse := false)
 runs on Zephyr_Tester
 {
-	var Result v_res;
-
 	map(mtc:pt, system:pt);
 
-	v_res := f_IPL4_listen(pt, p_local_addr, p_local_port, { udp := {} });
+	v_connId := f_udp_open(p_local_addr, p_local_port, p_reuse);
+}
+
+/* Open a further socket on the port that is already mapped. A suite needs one
+ * when it has to receive on one address and send from another, which happens
+ * whenever a protocol is broadcast: the address a broadcast arrives at is not
+ * one that says which link to answer on.
+ */
+function f_udp_open(in charstring p_local_addr, in integer p_local_port := 0,
+		    in boolean p_reuse := false)
+runs on Zephyr_Tester return ConnectionId
+{
+	var OptionList v_options := {};
+	var Result v_res;
+
+	if (p_reuse) {
+		v_options := { { reuseAddress := { enable := true } } };
+	}
+
+	v_res := f_IPL4_listen(pt, p_local_addr, p_local_port, { udp := {} }, v_options);
 	if (not ispresent(v_res.connId)) {
 		setverdict(fail, "cannot open a socket on ", p_local_addr, ":", p_local_port);
 		stop;
 	}
 
-	v_connId := v_res.connId;
+	return v_res.connId;
 }
 
 function f_close() runs on Zephyr_Tester
@@ -62,11 +80,21 @@ function f_close() runs on Zephyr_Tester
 	unmap(mtc:pt, system:pt);
 }
 
-function f_send_to(in charstring p_addr, in integer p_port, in octetstring p_msg)
+/* Send from the socket f_udp_listen opened, or from another one when a
+ * connection id is given.
+ */
+function f_send_to(in charstring p_addr, in integer p_port, in octetstring p_msg,
+		   in ConnectionId p_connId := -1)
 runs on Zephyr_Tester
 {
+	var ConnectionId v_from := p_connId;
+
+	if (v_from == -1) {
+		v_from := v_connId;
+	}
+
 	pt.send(ASP_SendTo:{
-		connId := v_connId,
+		connId := v_from,
 		remName := p_addr,
 		remPort := p_port,
 		proto := omit,

--- a/ttcn3/common/Zephyr_Transport.ttcn
+++ b/ttcn3/common/Zephyr_Transport.ttcn
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The part of a suite that is the same whatever protocol is being tested: a
+ * socket on the tester, and the handful of things every suite does with it.
+ *
+ * A suite extends Zephyr_Tester rather than declaring its own component, so
+ * that the functions here are available to it:
+ *
+ *     type component MY_MTC extends Zephyr_Tester { ... }
+ *
+ * Timeouts come from Zephyr_SUT, so that one configuration file can slow a
+ * whole run down for a loaded machine without touching any suite.
+ */
+module Zephyr_Transport {
+
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from Zephyr_SUT all;
+
+type component Zephyr_Tester {
+	port IPL4asp_PT pt;
+	var ConnectionId v_connId := -1;
+	timer t_guard;
+}
+
+/* Open an unconnected UDP socket on the tester.
+ *
+ * Unconnected is the point. A connected socket only accepts datagrams from
+ * the address it was connected to, which is wrong for anything that answers
+ * from an address other than the one it was asked at, and wrong for anything
+ * addressed to a group.
+ *
+ * A local port of zero asks the system for a free one.
+ */
+function f_udp_listen(in charstring p_local_addr, in integer p_local_port := 0)
+runs on Zephyr_Tester
+{
+	var Result v_res;
+
+	map(mtc:pt, system:pt);
+
+	v_res := f_IPL4_listen(pt, p_local_addr, p_local_port, { udp := {} });
+	if (not ispresent(v_res.connId)) {
+		setverdict(fail, "cannot open a socket on ", p_local_addr, ":", p_local_port);
+		stop;
+	}
+
+	v_connId := v_res.connId;
+}
+
+function f_close() runs on Zephyr_Tester
+{
+	if (v_connId != -1) {
+		f_IPL4_close(pt, v_connId);
+		v_connId := -1;
+	}
+
+	unmap(mtc:pt, system:pt);
+}
+
+function f_send_to(in charstring p_addr, in integer p_port, in octetstring p_msg)
+runs on Zephyr_Tester
+{
+	pt.send(ASP_SendTo:{
+		connId := v_connId,
+		remName := p_addr,
+		remPort := p_port,
+		proto := omit,
+		msg := p_msg
+	});
+}
+
+/* Wait for one datagram. Fails the test case and stops it if nothing arrives,
+ * so that callers can use the result without checking it first.
+ */
+function f_receive(in float p_timeout := -1.0) runs on Zephyr_Tester return ASP_RecvFrom
+{
+	var ASP_RecvFrom v_recv;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		t_guard.stop;
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "nothing arrived within ", v_timeout, "s");
+		stop;
+	}
+	}
+
+	return v_recv;
+}
+
+/* Require that nothing arrives. Staying quiet is a real answer in several
+ * protocols, so it needs checking as carefully as a reply does.
+ */
+function f_expect_silence(in charstring p_why, in float p_timeout := -1.0)
+runs on Zephyr_Tester
+{
+	var ASP_RecvFrom v_recv;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_silence_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		t_guard.stop;
+		setverdict(fail, "answered when it should have stayed quiet: ", p_why);
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+}

--- a/ttcn3/common/sources.txt
+++ b/ttcn3/common/sources.txt
@@ -1,6 +1,10 @@
 # Module sources every suite needs, relative to ../modules.
 # build.sh reads this before the suite's own sources.txt.
 
+# Base types the shared layer is written in terms of, and which most protocol
+# modules import in turn.
+titan.ProtocolModules.COMMON/src/General_Types.ttcn
+
 titan.TestPorts.IPL4asp/src/IPL4asp_Types.ttcn
 titan.TestPorts.IPL4asp/src/IPL4asp_PortType.ttcn
 titan.TestPorts.IPL4asp/src/IPL4asp_Functions.ttcn

--- a/ttcn3/common/sources.txt
+++ b/ttcn3/common/sources.txt
@@ -1,0 +1,19 @@
+# Module sources every suite needs, relative to ../modules.
+# build.sh reads this before the suite's own sources.txt.
+
+titan.TestPorts.IPL4asp/src/IPL4asp_Types.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_PortType.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_Functions.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_PT.cc
+titan.TestPorts.IPL4asp/src/IPL4asp_PT.hh
+titan.TestPorts.IPL4asp/src/IPL4asp_discovery.cc
+titan.TestPorts.IPL4asp/src/IPL4asp_protocol_L234.hh
+
+titan.TestPorts.Common_Components.Socket-API/src/Socket_API_Definitions.ttcn
+titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.cc
+titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.hh
+
+titan.Libraries.TCCUsefulFunctions/src/TCCConversion_Functions.ttcn
+titan.Libraries.TCCUsefulFunctions/src/TCCConversion.cc
+titan.Libraries.TCCUsefulFunctions/src/TCCInterface_Functions.ttcn
+titan.Libraries.TCCUsefulFunctions/src/TCCInterface.cc

--- a/ttcn3/fetch-modules.sh
+++ b/ttcn3/fetch-modules.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+#
+# Clone the third party TTCN-3 modules listed in modules.txt into modules/,
+# each checked out at its pinned commit. Re-running is cheap: a repository that
+# is already at the right commit is left alone.
+
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+modules_dir="$here/modules"
+url_base="https://gitlab.eclipse.org/eclipse/titan"
+
+mkdir -p "$modules_dir"
+
+while read -r repo commit; do
+	case "$repo" in
+	''|\#*) continue ;;
+	esac
+
+	dest="$modules_dir/$repo"
+
+	if [ -d "$dest/.git" ]; then
+		if [ "$(git -C "$dest" rev-parse HEAD)" = "$commit" ]; then
+			echo "$repo: already at $commit"
+			continue
+		fi
+	else
+		echo "$repo: cloning"
+		git clone -q "$url_base/$repo.git" "$dest"
+	fi
+
+	echo "$repo: checking out $commit"
+	git -C "$dest" fetch -q origin
+	git -C "$dest" checkout -q "$commit"
+done < "$here/modules.txt"
+
+echo "Modules are in $modules_dir"

--- a/ttcn3/modules.txt
+++ b/ttcn3/modules.txt
@@ -11,6 +11,7 @@ titan.ProtocolModules.CoAP                        db0da63d71e79e2075ca7bdd204403
 titan.misc                                        13454aa47843d4614a158b966c77490d0e5c5fbe
 titan.ProtocolModules.DHCP                        54a7944009686579a844c353c91ef22069d11320
 titan.ProtocolModules.COMMON                      7467160f763ab88e4b071dc057f58a764042e870
+titan.ProtocolModules.MQTT                        08dca6dabbd5f7ea2ab8e039ced93c7e3bae3438
 titan.ProtocolModules.NDP                         7acd3b551476ab56d26592afaeceecedec45e94c
 titan.ProtocolModules.IP                          0b4dab3f6eeaaf0532afb2ee5d82211faef05c69
 titan.ProtocolModules.TCP                         81c931982450d353f1d03402301d607dec5dab64

--- a/ttcn3/modules.txt
+++ b/ttcn3/modules.txt
@@ -11,6 +11,8 @@ titan.ProtocolModules.CoAP                        db0da63d71e79e2075ca7bdd204403
 titan.misc                                        13454aa47843d4614a158b966c77490d0e5c5fbe
 titan.ProtocolModules.DHCP                        54a7944009686579a844c353c91ef22069d11320
 titan.ProtocolModules.COMMON                      7467160f763ab88e4b071dc057f58a764042e870
+titan.ProtocolModules.IP                          0b4dab3f6eeaaf0532afb2ee5d82211faef05c69
+titan.ProtocolModules.TCP                         81c931982450d353f1d03402301d607dec5dab64
 titan.TestPorts.IPL4asp                           a4d5c2992368bc7b702759887e54b64a44c54de0
 titan.TestPorts.Common_Components.Abstract_Socket f6b2d2ba3f486dea778e108ce60e02a3fcae9ff8
 titan.TestPorts.Common_Components.Socket-API      37f8b1f04c0d6627bf5dbaf3b533bc5606f19b9c

--- a/ttcn3/modules.txt
+++ b/ttcn3/modules.txt
@@ -1,0 +1,13 @@
+# Third party TTCN-3 modules that the suites build against.
+#
+# Format: <repository name> <commit>
+#
+# The repositories live under https://gitlab.eclipse.org/eclipse/titan/ and are
+# cloned by fetch-modules.sh into modules/. Commits are pinned so that a suite
+# that passes today still builds tomorrow; see README.md for how to move a pin.
+
+titan.ProtocolModules.DNS                         8501da2fdfd0bd928025152801ac19973aca5891
+titan.TestPorts.IPL4asp                           a4d5c2992368bc7b702759887e54b64a44c54de0
+titan.TestPorts.Common_Components.Abstract_Socket f6b2d2ba3f486dea778e108ce60e02a3fcae9ff8
+titan.TestPorts.Common_Components.Socket-API      37f8b1f04c0d6627bf5dbaf3b533bc5606f19b9c
+titan.Libraries.TCCUsefulFunctions                b3801bffc18d285fe541a6cf48c1193ad8472723

--- a/ttcn3/modules.txt
+++ b/ttcn3/modules.txt
@@ -11,6 +11,7 @@ titan.ProtocolModules.CoAP                        db0da63d71e79e2075ca7bdd204403
 titan.misc                                        13454aa47843d4614a158b966c77490d0e5c5fbe
 titan.ProtocolModules.DHCP                        54a7944009686579a844c353c91ef22069d11320
 titan.ProtocolModules.COMMON                      7467160f763ab88e4b071dc057f58a764042e870
+titan.ProtocolModules.NDP                         7acd3b551476ab56d26592afaeceecedec45e94c
 titan.ProtocolModules.IP                          0b4dab3f6eeaaf0532afb2ee5d82211faef05c69
 titan.ProtocolModules.TCP                         81c931982450d353f1d03402301d607dec5dab64
 titan.TestPorts.IPL4asp                           a4d5c2992368bc7b702759887e54b64a44c54de0

--- a/ttcn3/modules.txt
+++ b/ttcn3/modules.txt
@@ -7,6 +7,8 @@
 # that passes today still builds tomorrow; see README.md for how to move a pin.
 
 titan.ProtocolModules.DNS                         8501da2fdfd0bd928025152801ac19973aca5891
+titan.ProtocolModules.CoAP                        db0da63d71e79e2075ca7bdd20440341d2dbfac1
+titan.misc                                        13454aa47843d4614a158b966c77490d0e5c5fbe
 titan.TestPorts.IPL4asp                           a4d5c2992368bc7b702759887e54b64a44c54de0
 titan.TestPorts.Common_Components.Abstract_Socket f6b2d2ba3f486dea778e108ce60e02a3fcae9ff8
 titan.TestPorts.Common_Components.Socket-API      37f8b1f04c0d6627bf5dbaf3b533bc5606f19b9c

--- a/ttcn3/modules.txt
+++ b/ttcn3/modules.txt
@@ -9,6 +9,8 @@
 titan.ProtocolModules.DNS                         8501da2fdfd0bd928025152801ac19973aca5891
 titan.ProtocolModules.CoAP                        db0da63d71e79e2075ca7bdd20440341d2dbfac1
 titan.misc                                        13454aa47843d4614a158b966c77490d0e5c5fbe
+titan.ProtocolModules.DHCP                        54a7944009686579a844c353c91ef22069d11320
+titan.ProtocolModules.COMMON                      7467160f763ab88e4b071dc057f58a764042e870
 titan.TestPorts.IPL4asp                           a4d5c2992368bc7b702759887e54b64a44c54de0
 titan.TestPorts.Common_Components.Abstract_Socket f6b2d2ba3f486dea778e108ce60e02a3fcae9ff8
 titan.TestPorts.Common_Components.Socket-API      37f8b1f04c0d6627bf5dbaf3b533bc5606f19b9c

--- a/ttcn3/suites/arp/ARP_Suite.ttcn
+++ b/ttcn3/suites/arp/ARP_Suite.ttcn
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for Zephyr's address resolution, RFC 826.
+ *
+ * This is the first suite to work below the IP layer, so it does not use the
+ * socket test port the others do. It reads and writes ethernet frames on the
+ * link directly, which needs privilege and a link where nothing else answers.
+ *
+ * That second part is why the system under test has an interface of its own.
+ * Linux answers address resolution for any address it holds on any interface
+ * unless told otherwise, and an answer from the host would be indistinguishable
+ * from an answer from Zephyr. The interface described in net-tools/zeth-l2.conf
+ * has no address at all and is told to answer for none, so everything on the
+ * link that is not the system under test is this suite.
+ *
+ * The system under test is tests/net/conformance/arp in the Zephyr tree.
+ */
+module ARP_Suite {
+
+import from General_Types all;
+import from ARP_Types all;
+import from Ethernet_Port all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+
+/* The hardware address the tester answers to, as twelve hexadecimal digits.
+ * The address is locally administered, so it cannot collide with a real one.
+ * It has to agree with eth_mac_source in the test port parameters, which is
+ * what the port puts in the frames it sends.
+ */
+modulepar charstring tsp_tester_mac := "020000000002";
+
+/* An address on the link that nothing owns, for asking about something the
+ * system under test should not answer for.
+ */
+modulepar charstring tsp_unclaimed_ipv4 := "192.0.2.77";
+
+type component ARP_MTC {
+	port Ethernet_PT pt;
+	timer t_guard;
+}
+
+function f_mac(in charstring p_mac) return OCT6
+{
+	return str2oct(p_mac);
+}
+
+function f_ipv4(in charstring p_addr) return OCT4
+{
+	return f_convertIPAddrToBinary(p_addr);
+}
+
+/* Mapping the port opens the interface, using the name, the hardware address
+ * and the type to filter on that are given in the test port parameters. The
+ * interface is named there rather than in a module parameter because the port
+ * reads it for itself before any test code runs.
+ *
+ * The filter matters. Without one the port hands up every frame on the link,
+ * and the datagrams the system under test sends would have to be skipped past
+ * in every test.
+ */
+function f_open() runs on ARP_MTC
+{
+	map(mtc:pt, system:pt);
+}
+
+function f_close() runs on ARP_MTC
+{
+	unmap(mtc:pt, system:pt);
+}
+
+function f_send_arp(in OCT6 p_eth_dst, in ARP_Packet p_arp) runs on ARP_MTC
+{
+	pt.send(Ethernet_Frame:{
+		destination := p_eth_dst,
+		source := f_mac(tsp_tester_mac),
+		etherType := c_ethertype_arp,
+		payload := bit2oct(encvalue(p_arp))
+	});
+}
+
+/* A request as a host on the link would send it: broadcast, asking who holds
+ * p_target and saying who is asking.
+ */
+function f_request(in charstring p_target, in OCT6 p_eth_dst := c_mac_broadcast)
+runs on ARP_MTC
+{
+	f_send_arp(p_eth_dst, {
+		hwType := c_arp_hw_ethernet,
+		protoType := c_arp_proto_ipv4,
+		hwLen := 6,
+		protoLen := 4,
+		operation := c_arp_request,
+		senderHwAddr := f_mac(tsp_tester_mac),
+		senderProtoAddr := f_ipv4(tsp_tester_ipv4),
+		targetHwAddr := c_mac_unspecified,
+		targetProtoAddr := f_ipv4(p_target)
+	});
+}
+
+/* Wait for the next address resolution frame from the system under test and
+ * hand back what it said. Fails the test case and stops it if nothing arrives.
+ */
+function f_await_arp() runs on ARP_MTC return ARP_Packet
+{
+	var Ethernet_Frame v_frame;
+	var bitstring v_bits;
+	var ARP_Packet v_arp;
+
+	t_guard.start(tsp_response_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		t_guard.stop;
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "nothing arrived within ", tsp_response_timeout, "s");
+		stop;
+	}
+	}
+
+	if (v_frame.etherType != c_ethertype_arp) {
+		setverdict(fail, "the filter let through something that is not "&
+			   "address resolution");
+		stop;
+	}
+
+	v_bits := oct2bit(v_frame.payload);
+	if (decvalue(v_bits, v_arp) != 0) {
+		setverdict(fail, "cannot decode the address resolution packet");
+		stop;
+	}
+
+	return v_arp;
+}
+
+/* Wait for a reply, skipping past requests. The system under test asks for the
+ * tester's address of its own accord, so a request can arrive at any time and
+ * is not what a test waiting for an answer is looking for.
+ */
+function f_await_reply() runs on ARP_MTC return ARP_Packet
+{
+	for (var integer i := 0; i < 8; i := i + 1) {
+		var ARP_Packet v_arp := f_await_arp();
+
+		if (v_arp.operation == c_arp_reply) {
+			return v_arp;
+		}
+	}
+
+	setverdict(fail, "no reply among the frames that arrived");
+	stop;
+}
+
+/* Require that no reply arrives. Requests are ignored, for the same reason. */
+function f_expect_no_reply(in charstring p_why) runs on ARP_MTC
+{
+	var Ethernet_Frame v_frame;
+	var bitstring v_bits;
+	var ARP_Packet v_arp;
+
+	t_guard.start(tsp_silence_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		v_bits := oct2bit(v_frame.payload);
+		if (decvalue(v_bits, v_arp) == 0 and v_arp.operation == c_arp_reply) {
+			t_guard.stop;
+			setverdict(fail, "answered when it should not have: ", p_why);
+		} else {
+			repeat;
+		}
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+function f_check_reply_shape(in ARP_Packet p_arp) runs on ARP_MTC
+{
+	if (p_arp.hwType != c_arp_hw_ethernet) {
+		setverdict(fail, "the hardware type is ", p_arp.hwType, " rather than ethernet");
+	}
+	if (p_arp.protoType != c_arp_proto_ipv4) {
+		setverdict(fail, "the protocol type is ", p_arp.protoType, " rather than IPv4");
+	}
+	if (p_arp.hwLen != 6 or p_arp.protoLen != 4) {
+		setverdict(fail, "the address lengths are ", p_arp.hwLen, " and ",
+			   p_arp.protoLen, " rather than 6 and 4");
+	}
+	if (p_arp.senderProtoAddr != f_ipv4(tsp_sut_ipv4)) {
+		setverdict(fail, "the reply is sent on behalf of somebody else");
+	}
+	if (p_arp.targetProtoAddr != f_ipv4(tsp_tester_ipv4)) {
+		setverdict(fail, "the reply is not addressed back to the asker");
+	}
+	if (p_arp.targetHwAddr != f_mac(tsp_tester_mac)) {
+		setverdict(fail, "the reply does not carry the asker's hardware address");
+	}
+}
+
+/* Asking who holds the address the system under test owns has to bring back a
+ * reply saying that it does. RFC 826.
+ */
+testcase tc_request_is_answered() runs on ARP_MTC
+{
+	var ARP_Packet v_reply;
+
+	f_open();
+	f_request(tsp_sut_ipv4);
+	v_reply := f_await_reply();
+	f_check_reply_shape(v_reply);
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A host answers only for addresses it holds. Answering for one it does not
+ * would send traffic meant for another host to it instead.
+ */
+testcase tc_request_for_another_address_is_ignored() runs on ARP_MTC
+{
+	f_open();
+	f_request(tsp_unclaimed_ipv4);
+	f_expect_no_reply("the address asked about is not one it holds");
+	f_close();
+}
+
+/* A reply is an answer, not a question, so it calls for nothing in return. A
+ * host that answers one can be made to flood a link by a single frame.
+ */
+testcase tc_reply_is_not_answered() runs on ARP_MTC
+{
+	f_open();
+
+	f_send_arp(f_mac(tsp_tester_mac), {
+		hwType := c_arp_hw_ethernet,
+		protoType := c_arp_proto_ipv4,
+		hwLen := 6,
+		protoLen := 4,
+		operation := c_arp_reply,
+		senderHwAddr := f_mac(tsp_tester_mac),
+		senderProtoAddr := f_ipv4(tsp_tester_ipv4),
+		targetHwAddr := c_mac_unspecified,
+		targetProtoAddr := f_ipv4(tsp_sut_ipv4)
+	});
+
+	f_expect_no_reply("a reply was sent, which asks for nothing");
+	f_close();
+}
+
+/* A request sent to the hardware address of the system under test rather than
+ * to everybody still has to be answered. RFC 826 says nothing about how a
+ * request was addressed, and a host that had been asked directly and stayed
+ * quiet would be unreachable to anything that remembered its address.
+ */
+testcase tc_unicast_request_is_answered() runs on ARP_MTC
+{
+	var ARP_Packet v_first;
+	var ARP_Packet v_reply;
+
+	f_open();
+
+	/* Learn the hardware address from an answer rather than from the
+	 * configuration, and rather than from a request it sends of its own
+	 * accord: by this point it has an entry for the tester and has stopped
+	 * asking.
+	 */
+	f_request(tsp_sut_ipv4);
+	v_first := f_await_reply();
+	f_check_reply_shape(v_first);
+
+	f_request(tsp_sut_ipv4, v_first.senderHwAddr);
+	v_reply := f_await_reply();
+	f_check_reply_shape(v_reply);
+
+	if (v_reply.senderHwAddr != v_first.senderHwAddr) {
+		setverdict(fail, "it answered a request addressed to it with a "&
+			   "different hardware address than it answered a "&
+			   "broadcast one with");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* Before sending to an address on the link that it has no entry for, a host
+ * has to ask for it. One that sent to a made up hardware address instead would
+ * have its traffic dropped by the switch.
+ */
+testcase tc_it_asks_before_it_sends() runs on ARP_MTC
+{
+	var ARP_Packet v_request;
+
+	f_open();
+
+	v_request := f_await_arp();
+	if (v_request.operation != c_arp_request) {
+		setverdict(fail, "expected it to ask for the address it sends to");
+		f_close();
+		stop;
+	}
+
+	if (v_request.targetProtoAddr != f_ipv4(tsp_tester_ipv4)) {
+		setverdict(fail, "it asked about somebody other than the host "&
+			   "it is sending to");
+	}
+	if (v_request.senderProtoAddr != f_ipv4(tsp_sut_ipv4)) {
+		setverdict(fail, "it asked without saying who is asking, so the "&
+			   "answer has nowhere to go");
+	}
+	if (v_request.targetHwAddr != c_mac_unspecified) {
+		setverdict(fail, "it filled in the hardware address it is asking for");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+control {
+	execute(tc_it_asks_before_it_sends());
+	execute(tc_request_is_answered());
+	execute(tc_unicast_request_is_answered());
+	execute(tc_request_for_another_address_is_ignored());
+	execute(tc_reply_is_not_answered());
+}
+
+}

--- a/ttcn3/suites/arp/ARP_Types.ttcn
+++ b/ttcn3/suites/arp/ARP_Types.ttcn
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Address resolution packets, RFC 826.
+ *
+ * The Titan project publishes no protocol module for this one, and the packet
+ * is small enough that writing it out is easier than depending on something
+ * that would have to be found first. Only the ethernet and IPv4 case is
+ * described, which is the only case that occurs here: the lengths are fixed
+ * rather than driving the field widths.
+ */
+module ARP_Types {
+
+import from General_Types all;
+
+type record ARP_Packet {
+	OCT2 hwType,
+	OCT2 protoType,
+	INT1 hwLen,
+	INT1 protoLen,
+	OCT2 operation,
+	OCT6 senderHwAddr,
+	OCT4 senderProtoAddr,
+	OCT6 targetHwAddr,
+	OCT4 targetProtoAddr
+}
+
+const OCT2 c_arp_hw_ethernet := '0001'O;
+const OCT2 c_arp_proto_ipv4 := '0800'O;
+const OCT2 c_arp_request := '0001'O;
+const OCT2 c_arp_reply := '0002'O;
+
+const OCT2 c_ethertype_arp := '0806'O;
+
+const OCT6 c_mac_broadcast := 'FFFFFFFFFFFF'O;
+const OCT6 c_mac_unspecified := '000000000000'O;
+
+} with { encode "RAW" }

--- a/ttcn3/suites/arp/arp.cfg
+++ b/ttcn3/suites/arp/arp.cfg
@@ -1,0 +1,35 @@
+# Runtime configuration for the address resolution conformance suite.
+#
+# This suite works on its own interface, the one net-tools/zeth-l2.conf
+# describes: it has no address on the Linux side, so that nothing but this
+# suite answers on the link.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_response_timeout := 15.0
+Zephyr_SUT.tsp_silence_timeout := 6.0
+
+# Twelve hexadecimal digits, no separators. Has to agree with eth_mac_source
+# below, which is what the test port puts in the frames it sends.
+ARP_Suite.tsp_tester_mac := "020000000002"
+ARP_Suite.tsp_unclaimed_ipv4 := "192.0.2.77"
+
+[TESTPORT_PARAMETERS]
+# The port opens the interface when the port is mapped, so it reads all of
+# this for itself before any test code runs.
+system.pt.interface := "zethL2"
+system.pt.source_address := "020000000002"
+# Only address resolution reaches the tests; everything else on the link,
+# including the datagrams the system under test sends, is filtered out.
+system.pt.ethertype := "0806"
+
+[LOGGING]
+LogFile := "arp-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+ARP_Suite.control

--- a/ttcn3/suites/arp/build.conf
+++ b/ttcn3/suites/arp/build.conf
@@ -1,0 +1,7 @@
+# The tester reads and writes ethernet frames directly, which needs a packet
+# socket, which needs privilege an ordinary user does not have.
+PRIVILEGED=yes
+
+# It works below the IP layer, so it uses the interface that has no address
+# on the Linux side rather than the one the other suites share.
+L2=yes

--- a/ttcn3/suites/arp/sources.txt
+++ b/ttcn3/suites/arp/sources.txt
@@ -1,0 +1,7 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+#
+# The ethernet port this suite reads and writes frames with is written here,
+# in common/, rather than taken from the Titan project. See Ethernet_Port.ttcn
+# for why.
+

--- a/ttcn3/suites/coap/build.conf
+++ b/ttcn3/suites/coap/build.conf
@@ -1,0 +1,4 @@
+# The ETSI test cases create parallel test components, which single mode
+# cannot do, so this suite is built and run in parallel mode: a main
+# controller plus a host controller rather than one executable.
+MODE=parallel

--- a/ttcn3/suites/coap/coap.cfg
+++ b/ttcn3/suites/coap/coap.cfg
@@ -1,0 +1,45 @@
+# Runtime configuration for the CoAP server conformance suite.
+#
+# The test cases come from the ETSI derived CoAP suite that the Titan project
+# publishes in titan.misc. This file points that suite at Zephyr and selects
+# the cases to run.
+#
+# "server" is the system under test, tests/net/conformance/coap. "client" is
+# this tester. The suite also knows about a "ctrl" and a "sut_app" address,
+# which belong to its own framework self tests rather than to the ETSI cases,
+# and are left at the loopback defaults because nothing here uses them.
+
+[MODULE_PARAMETERS]
+CoapFramework.tsp_addresses := {
+	{ id := "client",  hostName := "192.0.2.2", portNumber := 31111 },
+	{ id := "server",  hostName := "192.0.2.1", portNumber := 5683 },
+	{ id := "ctrl",    hostName := "127.0.0.1", portNumber := 32222 },
+	{ id := "sut_app", hostName := "127.0.0.1", portNumber := 33333 }
+}
+
+[LOGGING]
+LogFile := "coap-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_01
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_02
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_03
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_04
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_05
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_06
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_07
+CoapTestSuite_Etsi.tc_client_TD_COAP_CORE_08
+
+# TD_COAP_BLOCK_01 and TD_COAP_OBS_01 are deliberately not run. They address
+# a /large and an /obs resource, and the system under test provides only
+# /test. Against it they do not merely fail: the observe case then waits for
+# notifications that never arrive and the run does not finish. Adding those
+# resources, and these two cases with them, is the next thing to do here.
+
+[MAIN_CONTROLLER]
+TCPPort := 0
+KillTimer := 10.0

--- a/ttcn3/suites/coap/sources.txt
+++ b/ttcn3/suites/coap/sources.txt
@@ -1,0 +1,16 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+#
+# The test cases are not written here: they are the ETSI derived CoAP suite
+# that the Titan project publishes in titan.misc. This suite contributes the
+# configuration that points it at Zephyr, and the list of cases that are
+# expected to pass.
+
+titan.ProtocolModules.CoAP/src/CoAP_Types.ttcn
+titan.ProtocolModules.CoAP/src/CoAP_EncDec.cc
+
+titan.misc/CoAP_Conf/src/CoapCommon.ttcn
+titan.misc/CoAP_Conf/src/CoapFramework.ttcn
+titan.misc/CoAP_Conf/src/CoapPeer.ttcn
+titan.misc/CoAP_Conf/src/CoapApplication.ttcn
+titan.misc/CoAP_Conf/src/CoapTestSuite_Etsi.ttcn

--- a/ttcn3/suites/dhcpv4/DHCPv4_Suite.ttcn
+++ b/ttcn3/suites/dhcpv4/DHCPv4_Suite.ttcn
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for the Zephyr DHCPv4 client.
+ *
+ * The tester is the server. It listens on the port DHCP servers listen on,
+ * which is why this suite needs to be allowed a privileged port: the ports
+ * are written into RFC 2131 and cannot be moved.
+ *
+ * Answers go to the broadcast address rather than to the client. A client
+ * that has not been given an address yet cannot be reached at one, and
+ * reaching it by hardware address instead would mean writing the frame
+ * ourselves.
+ *
+ * One thing is deliberately not tested. RFC 2131 4.1 has a client use the
+ * same transaction identifier for every message of one transaction, and the
+ * client here counts it up by one on each retransmission of a discover
+ * instead. That is worth knowing, both because a server may treat the
+ * retransmissions as separate clients and because an identifier that counts
+ * up is one an off path attacker can guess, but a test that asserted the
+ * current behaviour would fail the day it was corrected.
+ *
+ * The system under test is tests/net/conformance/dhcpv4 in the Zephyr tree.
+ */
+module DHCPv4_Suite {
+
+import from General_Types all;
+import from DHCP_Types all;
+import from DHCP_Options all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+import from Zephyr_Transport all;
+
+/* Fixed by RFC 2131 2. */
+const integer c_server_port := 67;
+const integer c_client_port := 68;
+
+const charstring c_broadcast := "255.255.255.255";
+
+/* What the tester hands out. Anything on the link will do: the tests look at
+ * what the client says, not at what it does with the address afterwards.
+ */
+modulepar charstring tsp_offered_address := "192.0.2.100";
+modulepar charstring tsp_subnet_mask := "255.255.255.0";
+modulepar integer tsp_lease_time := 600;
+
+type component DHCPv4_MTC extends Zephyr_Tester {
+	/* Replies go out through a second socket, see f_open. */
+	var ConnectionId v_reply_connId := -1;
+}
+
+/* Two sockets on the same port, for the two halves of the exchange.
+ *
+ * Messages arrive addressed to the broadcast address, which only a socket
+ * bound to the wildcard address sees. Replies go to the broadcast address in
+ * turn, and a socket bound to the wildcard has nothing to say which link that
+ * means, so the reply would leave through whichever interface the host routes
+ * a broadcast to. Binding the second socket to the address facing the device
+ * settles it.
+ */
+function f_open() runs on DHCPv4_MTC
+{
+	f_udp_listen("0.0.0.0", c_server_port, true);
+	v_reply_connId := f_udp_open(tsp_tester_ipv4, c_server_port, true);
+}
+
+function f_close_all() runs on DHCPv4_MTC
+{
+	if (v_reply_connId != -1) {
+		f_IPL4_close(pt, v_reply_connId);
+		v_reply_connId := -1;
+	}
+
+	f_close();
+}
+
+/* Wait for the next message from the client and hand back the BOOTP request
+ * inside it. Fails the test case and stops it if nothing arrives or if what
+ * arrives is not a request, so callers can use the result directly.
+ */
+function f_await_request() runs on DHCPv4_MTC return DHCP_MSG
+{
+	var ASP_RecvFrom v_recv := f_receive();
+	var PDU_DHCP v_pdu := dec_PDU_DHCP(v_recv.msg);
+
+	if (ischosen(v_pdu.erroneousPDU)) {
+		setverdict(fail, "the client sent something that is not a DHCP message");
+		stop;
+	}
+
+	if (not ischosen(v_pdu.bOOT_REQUEST)) {
+		setverdict(fail, "the client sent a reply rather than a request");
+		stop;
+	}
+
+	return v_pdu.bOOT_REQUEST;
+}
+
+/* The message type is an option rather than a field, so it has to be looked
+ * up. A message without one is not a DHCP message at all, only BOOTP.
+ */
+function f_message_type(in DHCP_MSG p_msg) runs on DHCPv4_MTC return DHCP_Message_Types
+{
+	if (not ispresent(p_msg.options)) {
+		setverdict(fail, "the message carries no options at all");
+		stop;
+	}
+
+	for (var integer i := 0; i < lengthof(p_msg.options.options); i := i + 1) {
+		if (ischosen(p_msg.options.options[i].message_type)) {
+			return p_msg.options.options[i].message_type.val;
+		}
+	}
+
+	setverdict(fail, "the message carries no message type option");
+	stop;
+}
+
+function f_has_option(in DHCP_MSG p_msg, in DHCP_Option_Type p_code) return boolean
+{
+	if (not ispresent(p_msg.options)) {
+		return false;
+	}
+
+	for (var integer i := 0; i < lengthof(p_msg.options.options); i := i + 1) {
+		var DHCP_GENERAL_OPTION v_general;
+
+		if (ischosen(p_msg.options.options[i].general)) {
+			v_general := p_msg.options.options[i].general;
+			if (oct2int(v_general.code) == enum2int(p_code)) {
+				return true;
+			}
+			continue;
+		}
+
+		select (p_code) {
+		case (DHCP_Message_Type_OPTION_TYPE) {
+			if (ischosen(p_msg.options.options[i].message_type)) { return true; }
+		}
+		case (DHCP_Parameter_request_list_OPTION_TYPE) {
+			if (ischosen(p_msg.options.options[i].parameter_request_list)) { return true; }
+		}
+		case (DHCP_Requested_IP_Address_OPTION_TYPE) {
+			if (ischosen(p_msg.options.options[i].requested_IP_address)) { return true; }
+		}
+		case (DHCP_Server_Identifier_OPTION_TYPE) {
+			if (ischosen(p_msg.options.options[i].server_identifier)) { return true; }
+		}
+		case else { }
+		}
+	}
+
+	return false;
+}
+
+/* A reply that mirrors the request it answers: same transaction, same
+ * hardware address, and the address the tester is handing out.
+ */
+function f_reply(in DHCP_MSG p_request, in DHCP_Message_Types p_type) runs on DHCPv4_MTC
+{
+	var octetstring v_server := f_convertIPAddrToBinary(tsp_tester_ipv4);
+	var PDU_DHCP v_pdu;
+
+	v_pdu := {
+		bOOT_REPLY := {
+			op := 2,
+			htype := DHCP_HTYPE_Ethernet_10Mb,
+			hlen := 6,
+			hops := 0,
+			xid := p_request.xid,
+			secs := 0,
+			flags := p_request.flags,
+			ciaddr := '00000000'O,
+			yiaddr := f_convertIPAddrToBinary(tsp_offered_address),
+			siaddr := v_server,
+			giaddr := '00000000'O,
+			chaddr := p_request.chaddr,
+			sname := { sname := "" },
+			file := { file := "" },
+			options := {
+				magicCookie := '63825363'O,
+				options := {
+					{ message_type := {
+						code := DHCP_Message_Type_OPTION_TYPE,
+						len := 1,
+						val := p_type } },
+					{ server_identifier := {
+						code := DHCP_Server_Identifier_OPTION_TYPE,
+						len := 4,
+						val := v_server } },
+					{ IP_address_lease_time := {
+						code := DHCP_IP_Address_Lease_Time_OPTION_TYPE,
+						len := 4,
+						val := tsp_lease_time } },
+					{ subnet_mask := {
+						code := DHCP_Subnet_Mask_OPTION_TYPE,
+						len := 4,
+						val := f_convertIPAddrToBinary(tsp_subnet_mask) } },
+					{ end := { code := DHCP_END_OPTION_TYPE } }
+				}
+			}
+		}
+	};
+
+	f_send_to(c_broadcast, c_client_port, enc_PDU_DHCP(v_pdu), v_reply_connId);
+}
+
+function f_check_request_shape(in DHCP_MSG p_msg) runs on DHCPv4_MTC
+{
+	if (p_msg.htype != DHCP_HTYPE_Ethernet_10Mb) {
+		setverdict(fail, "hardware type is ", p_msg.htype, " rather than ethernet");
+	}
+	if (p_msg.hlen != 6) {
+		setverdict(fail, "hardware address length is ", p_msg.hlen, " rather than 6");
+	}
+	if (p_msg.hops != 0) {
+		setverdict(fail, "hops is ", p_msg.hops,
+			   ", which only a relay agent should set");
+	}
+	if (p_msg.giaddr != '00000000'O) {
+		setverdict(fail, "the relay agent address is set on a message from a client");
+	}
+	if (not ispresent(p_msg.options)) {
+		setverdict(fail, "the message carries no options");
+		return;
+	}
+	if (p_msg.options.magicCookie != '63825363'O) {
+		setverdict(fail, "the option field does not start with the magic cookie");
+	}
+}
+
+/* A discover has to say what it is and what it wants to be told, and leave
+ * the fields that belong to a server or a relay alone. RFC 2131 4.4.1.
+ */
+testcase tc_discover_is_well_formed() runs on DHCPv4_MTC
+{
+	var DHCP_MSG v_discover;
+
+	f_open();
+	v_discover := f_await_request();
+	f_check_request_shape(v_discover);
+
+	if (f_message_type(v_discover) != DHCP_Discover) {
+		setverdict(fail, "the first message is not a discover");
+	}
+	if (v_discover.ciaddr != '00000000'O) {
+		setverdict(fail, "a client with no address yet filled in ciaddr");
+	}
+	if (not f_has_option(v_discover, DHCP_Parameter_request_list_OPTION_TYPE)) {
+		setverdict(fail, "the discover asks for nothing, so a server has " &
+			   "no idea what to send back");
+	}
+
+	setverdict(pass);
+	f_close_all();
+}
+
+/* Answering a discover has to bring back a request naming the address that
+ * was offered and the server that offered it: without both, a client on a
+ * link with two servers cannot say which offer it took. Acknowledging that
+ * request finishes the exchange, after which the client has an address and
+ * no reason to keep asking. RFC 2131 4.3.2.
+ */
+testcase tc_exchange_completes() runs on DHCPv4_MTC
+{
+	var DHCP_MSG v_discover;
+	var DHCP_MSG v_request;
+
+	f_open();
+
+	v_discover := f_await_request();
+	if (f_message_type(v_discover) != DHCP_Discover) {
+		setverdict(fail, "expected a discover to answer");
+		f_close_all();
+		stop;
+	}
+
+	f_reply(v_discover, DHCP_Offer);
+
+	v_request := f_await_request();
+	f_check_request_shape(v_request);
+
+	if (f_message_type(v_request) != DHCP_Request) {
+		setverdict(fail, "the offer did not bring back a request");
+		f_close_all();
+		stop;
+	}
+	if (v_request.xid != v_discover.xid) {
+		setverdict(fail, "the request belongs to a different transaction " &
+			   "than the offer it answers");
+	}
+	if (v_request.chaddr != v_discover.chaddr) {
+		setverdict(fail, "the request carries a different hardware address");
+	}
+	if (not f_has_option(v_request, DHCP_Server_Identifier_OPTION_TYPE)) {
+		setverdict(fail, "the request does not say which server it is for");
+	}
+	if (not f_has_option(v_request, DHCP_Requested_IP_Address_OPTION_TYPE)) {
+		setverdict(fail, "the request does not say which address it wants");
+	}
+
+	f_reply(v_request, DHCP_Ack);
+
+	f_expect_silence("the exchange was acknowledged, so it is finished");
+	f_close_all();
+}
+
+/* A client whose discover goes unanswered has to keep asking rather than give
+ * up, otherwise a server that was slow to start is never found.
+ */
+testcase tc_unanswered_discover_is_repeated() runs on DHCPv4_MTC
+{
+	var DHCP_MSG v_first;
+	var DHCP_MSG v_next;
+
+	f_open();
+	v_first := f_await_request();
+	if (f_message_type(v_first) != DHCP_Discover) {
+		setverdict(fail, "the first message is not a discover");
+		f_close_all();
+		stop;
+	}
+
+	/* Say nothing, and wait for the client to ask again. */
+	v_next := f_await_request();
+	f_check_request_shape(v_next);
+
+	if (f_message_type(v_next) != DHCP_Discover) {
+		setverdict(fail, "the client moved on without ever being offered anything");
+	}
+	if (v_next.chaddr != v_first.chaddr) {
+		setverdict(fail, "the client changed its hardware address between discovers");
+	}
+
+	setverdict(pass);
+	f_close_all();
+}
+
+/* The acknowledged case runs last on purpose. It is the one that leaves the
+ * system under test holding an address, and a client that has one has no
+ * reason to ask for another, so nothing after it would see a discover.
+ */
+/* The order matters. Only one exchange can be completed, because a client
+ * that has been given an address stops asking for one, so the case that
+ * completes it runs last.
+ */
+control {
+	execute(tc_unanswered_discover_is_repeated());
+	execute(tc_discover_is_well_formed());
+	execute(tc_exchange_completes());
+}
+
+}

--- a/ttcn3/suites/dhcpv4/DHCPv4_Suite.ttcn
+++ b/ttcn3/suites/dhcpv4/DHCPv4_Suite.ttcn
@@ -15,14 +15,6 @@
  * reaching it by hardware address instead would mean writing the frame
  * ourselves.
  *
- * One thing is deliberately not tested. RFC 2131 4.1 has a client use the
- * same transaction identifier for every message of one transaction, and the
- * client here counts it up by one on each retransmission of a discover
- * instead. That is worth knowing, both because a server may treat the
- * retransmissions as separate clients and because an identifier that counts
- * up is one an off path attacker can guess, but a test that asserted the
- * current behaviour would fail the day it was corrected.
- *
  * The system under test is tests/net/conformance/dhcpv4 in the Zephyr tree.
  */
 module DHCPv4_Suite {
@@ -335,6 +327,16 @@ testcase tc_unanswered_discover_is_repeated() runs on DHCPv4_MTC
 	}
 	if (v_next.chaddr != v_first.chaddr) {
 		setverdict(fail, "the client changed its hardware address between discovers");
+	}
+
+	/* RFC 2131 4.1: one identifier for every message of one exchange. A
+	 * retransmission is the same exchange, so a server that has already
+	 * seen the first one recognises the second as a repeat rather than as
+	 * another client asking.
+	 */
+	if (v_next.xid != v_first.xid) {
+		setverdict(fail, "the retransmitted discover carries a different "&
+			   "transaction identifier, so it looks like a new exchange");
 	}
 
 	setverdict(pass);

--- a/ttcn3/suites/dhcpv4/build.conf
+++ b/ttcn3/suites/dhcpv4/build.conf
@@ -1,0 +1,5 @@
+# DHCP is defined on ports 67 and 68, and there is no way to move it
+# elsewhere, so the tester has to be allowed to bind a privileged port. The
+# harness checks for that and skips the suite rather than failing when it
+# cannot.
+PRIVILEGED=yes

--- a/ttcn3/suites/dhcpv4/dhcpv4.cfg
+++ b/ttcn3/suites/dhcpv4/dhcpv4.cfg
@@ -1,0 +1,33 @@
+# Runtime configuration for the DHCPv4 client conformance suite.
+#
+# The tester is the server here, and listens on the port DHCP servers listen
+# on. That port is privileged and cannot be moved: RFC 2131 writes both ports
+# into the protocol.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+# The client backs off between discovers, four seconds and then doubling to a
+# ceiling of a minute, and a test case has to be able to wait out the longest
+# of those.
+Zephyr_SUT.tsp_response_timeout := 75.0
+Zephyr_SUT.tsp_silence_timeout := 10.0
+
+DHCPv4_Suite.tsp_offered_address := "192.0.2.100"
+DHCPv4_Suite.tsp_subnet_mask := "255.255.255.0"
+DHCPv4_Suite.tsp_lease_time := 600
+
+[TESTPORT_PARAMETERS]
+# Answers go to the broadcast address, because a client that has not been
+# given an address yet cannot be reached at one. Sending there is refused
+# unless the socket has been told to expect it.
+system.pt.broadcast := "enabled"
+
+[LOGGING]
+LogFile := "dhcpv4-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+DHCPv4_Suite.control

--- a/ttcn3/suites/dhcpv4/sources.txt
+++ b/ttcn3/suites/dhcpv4/sources.txt
@@ -1,0 +1,8 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+
+titan.ProtocolModules.COMMON/src/General_Types.ttcn
+
+titan.ProtocolModules.DHCP/src/DHCP_Options.ttcn
+titan.ProtocolModules.DHCP/src/DHCP_Types.ttcn
+titan.ProtocolModules.DHCP/src/DHCP_EncDec.cc

--- a/ttcn3/suites/dhcpv4/sources.txt
+++ b/ttcn3/suites/dhcpv4/sources.txt
@@ -1,8 +1,6 @@
 # Module sources this suite needs on top of common/sources.txt,
 # relative to ../../modules.
 
-titan.ProtocolModules.COMMON/src/General_Types.ttcn
-
 titan.ProtocolModules.DHCP/src/DHCP_Options.ttcn
 titan.ProtocolModules.DHCP/src/DHCP_Types.ttcn
 titan.ProtocolModules.DHCP/src/DHCP_EncDec.cc

--- a/ttcn3/suites/dhcpv4_server/DHCPv4_Server_Suite.ttcn
+++ b/ttcn3/suites/dhcpv4_server/DHCPv4_Server_Suite.ttcn
@@ -1,0 +1,664 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for the Zephyr DHCPv4 server, RFC 2131.
+ *
+ * The mirror image of the DHCPv4 client suite: here the tester is the client,
+ * so it listens on the port a client listens on, which is why this suite needs
+ * a privileged port too. The ports are written into RFC 2131 2 and cannot be
+ * moved.
+ *
+ * Every message the tester sends asks for a broadcast reply. RFC 2131 4.1
+ * has the server answer a client that has no address yet either by broadcast
+ * or by writing the frame to the hardware address itself, and the second of
+ * those would be addressed to an address nothing on this host holds. Setting
+ * the flag is what a real client in that position does, so nothing is
+ * distorted by asking for it.
+ *
+ * Each test case appears as a client of its own, with its own hardware address
+ * and transaction identifier, so that no test depends on what an earlier one
+ * left behind. The server keeps its bindings for the life of the run, so the
+ * pool in the system under test is larger than the default to leave room.
+ *
+ * The system under test is tests/net/conformance/dhcpv4_server in the Zephyr
+ * tree.
+ */
+module DHCPv4_Server_Suite {
+
+import from General_Types all;
+import from DHCP_Types all;
+import from DHCP_Options all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+import from Zephyr_Transport all;
+
+/* Fixed by RFC 2131 2. */
+const integer c_server_port := 67;
+const integer c_client_port := 68;
+
+const charstring c_broadcast := "255.255.255.255";
+
+/* RFC 2131 2, the BROADCAST flag. */
+const OCT2 c_flags_broadcast := '8000'O;
+
+const OCT4 c_addr_any := '00000000'O;
+const OCT4 c_magic_cookie := '63825363'O;
+
+/* The lowest address the system under test hands out, and how many it has.
+ * Has to match what the application passes to net_dhcpv4_server_start() and
+ * CONFIG_NET_DHCPV4_SERVER_ADDR_COUNT.
+ */
+modulepar charstring tsp_pool_base := "192.0.2.100";
+modulepar integer tsp_pool_size := 16;
+
+/* An address on a different network from the one the server serves, for the
+ * test that asks for something the server cannot give.
+ */
+modulepar charstring tsp_foreign_address := "198.51.100.5";
+
+/* What the tester asks for as a lease, in seconds. */
+modulepar integer tsp_lease_request := 600;
+
+type component DHCPv4_Server_MTC extends Zephyr_Tester {
+	/* Messages leave through a second socket, see f_open. */
+	var ConnectionId v_send_connId := -1;
+}
+
+/* Who the tester is pretending to be. The server tells clients apart by the
+ * hardware address when there is no client identifier option, so a test that
+ * wants to be somebody new only has to pick a different one.
+ */
+type record ClientId {
+	OCT16 chaddr,
+	OCT4 xid
+}
+
+/* Two sockets on the same port, for the two halves of the exchange.
+ *
+ * Replies arrive addressed to the broadcast address, which only a socket bound
+ * to the wildcard address sees. Messages go to the broadcast address in turn,
+ * and a socket bound to the wildcard has nothing to say which link that means,
+ * so the message would leave through whichever interface the host routes a
+ * broadcast to. Binding the second socket to the address facing the device
+ * settles it.
+ *
+ * A reply to an Inform is addressed to the tester rather than broadcast, and
+ * arrives on the second socket. Both are on the same port, so either way it
+ * reaches the same receive statement.
+ */
+function f_open() runs on DHCPv4_Server_MTC
+{
+	f_udp_listen("0.0.0.0", c_client_port, true);
+	v_send_connId := f_udp_open(tsp_tester_ipv4, c_client_port, true);
+}
+
+function f_close_all() runs on DHCPv4_Server_MTC
+{
+	if (v_send_connId != -1) {
+		f_IPL4_close(pt, v_send_connId);
+		v_send_connId := -1;
+	}
+
+	f_close();
+}
+
+/* A hardware address and a transaction identifier that no other test uses. */
+function f_client(in integer p_index) return ClientId
+{
+	return {
+		chaddr := '02'O & '0000'O & int2oct(p_index, 3) & '00000000000000000000'O,
+		xid := 'C0DE'O & int2oct(p_index, 2)
+	};
+}
+
+function f_addr(in charstring p_addr) return OCT4
+{
+	return f_convertIPAddrToBinary(p_addr);
+}
+
+/* Whether an address is one the server said it would hand out. */
+function f_in_pool(in OCT4 p_addr) return boolean
+{
+	var integer v_base := oct2int(f_addr(tsp_pool_base));
+	var integer v_addr := oct2int(p_addr);
+
+	return v_addr >= v_base and v_addr < v_base + tsp_pool_size;
+}
+
+function f_opt_server_id() return DHCP_OPTION
+{
+	return { server_identifier := {
+			code := DHCP_Server_Identifier_OPTION_TYPE,
+			len := 4,
+			val := f_addr(tsp_sut_ipv4) } };
+}
+
+function f_opt_requested_ip(in OCT4 p_addr) return DHCP_OPTION
+{
+	return { requested_IP_address := {
+			code := DHCP_Requested_IP_Address_OPTION_TYPE,
+			len := 4,
+			val := p_addr } };
+}
+
+function f_opt_lease_time(in integer p_seconds) return DHCP_OPTION
+{
+	return { IP_address_lease_time := {
+			code := DHCP_IP_Address_Lease_Time_OPTION_TYPE,
+			len := 4,
+			val := p_seconds } };
+}
+
+/* A message from the client, with the message type option first and the end
+ * option last, which is where RFC 2131 3 puts them.
+ */
+function f_client_msg(in ClientId p_client, in DHCP_Message_Types p_type,
+		      in OCT4 p_ciaddr, in DHCP_OPTIONS p_options)
+return DHCP_MSG
+{
+	/* The concatenation needs both sides to have a type of their own, so
+	 * the two fixed options cannot be written into the expression.
+	 */
+	var DHCP_OPTIONS v_head := { { message_type := {
+					code := DHCP_Message_Type_OPTION_TYPE,
+					len := 1,
+					val := p_type } } };
+	var DHCP_OPTIONS v_tail := { { end := { code := DHCP_END_OPTION_TYPE } } };
+
+	return {
+		op := 1,
+		htype := DHCP_HTYPE_Ethernet_10Mb,
+		hlen := 6,
+		hops := 0,
+		xid := p_client.xid,
+		secs := 0,
+		flags := c_flags_broadcast,
+		ciaddr := p_ciaddr,
+		yiaddr := c_addr_any,
+		siaddr := c_addr_any,
+		giaddr := c_addr_any,
+		chaddr := p_client.chaddr,
+		sname := { sname := "" },
+		file := { file := "" },
+		options := {
+			magicCookie := c_magic_cookie,
+			options := v_head & p_options & v_tail
+		}
+	};
+}
+
+function f_send_msg(in DHCP_MSG p_msg) runs on DHCPv4_Server_MTC
+{
+	f_send_to(c_broadcast, c_server_port,
+		  enc_PDU_DHCP({ bOOT_REQUEST := p_msg }), v_send_connId);
+}
+
+/* Wait for the next reply. Fails the test case and stops it if nothing
+ * arrives or if what arrives is not a reply, so callers can use the result.
+ */
+function f_await_reply() runs on DHCPv4_Server_MTC return DHCP_MSG
+{
+	var ASP_RecvFrom v_recv := f_receive();
+	var PDU_DHCP v_pdu := dec_PDU_DHCP(v_recv.msg);
+
+	if (ischosen(v_pdu.erroneousPDU)) {
+		setverdict(fail, "the server sent something that is not a DHCP message");
+		stop;
+	}
+
+	if (not ischosen(v_pdu.bOOT_REPLY)) {
+		setverdict(fail, "the server sent a request rather than a reply");
+		stop;
+	}
+
+	return v_pdu.bOOT_REPLY;
+}
+
+/* The message type is an option rather than a field, so it has to be looked
+ * up. A message without one is not a DHCP message at all, only BOOTP.
+ */
+function f_message_type(in DHCP_MSG p_msg) runs on DHCPv4_Server_MTC
+return DHCP_Message_Types
+{
+	if (not ispresent(p_msg.options)) {
+		setverdict(fail, "the reply carries no options at all");
+		stop;
+	}
+
+	for (var integer i := 0; i < lengthof(p_msg.options.options); i := i + 1) {
+		if (ischosen(p_msg.options.options[i].message_type)) {
+			return p_msg.options.options[i].message_type.val;
+		}
+	}
+
+	setverdict(fail, "the reply carries no message type option, so a client "&
+		   "cannot tell what it is");
+	stop;
+}
+
+/* The server identifier, which a client needs in order to address the request
+ * that accepts an offer. RFC 2131 4.3.1 requires it in every reply but a Nak
+ * generated by a relay agent.
+ */
+function f_server_id(in DHCP_MSG p_msg) runs on DHCPv4_Server_MTC return OCT4
+{
+	if (ispresent(p_msg.options)) {
+		for (var integer i := 0; i < lengthof(p_msg.options.options); i := i + 1) {
+			if (ischosen(p_msg.options.options[i].server_identifier)) {
+				return p_msg.options.options[i].server_identifier.val;
+			}
+		}
+	}
+
+	setverdict(fail, "the reply carries no server identifier option");
+	stop;
+}
+
+/* The lease time, or -1 when the reply does not carry one. */
+function f_lease_time(in DHCP_MSG p_msg) return integer
+{
+	if (ispresent(p_msg.options)) {
+		for (var integer i := 0; i < lengthof(p_msg.options.options); i := i + 1) {
+			if (ischosen(p_msg.options.options[i].IP_address_lease_time)) {
+				return p_msg.options.options[i].IP_address_lease_time.val;
+			}
+		}
+	}
+
+	return -1;
+}
+
+/* Wait for a reply that belongs to this client and is of the type expected.
+ * Anything else fails the test rather than being skipped over: a reply to
+ * somebody else's transaction on a link with one client on it is a fault in
+ * itself.
+ */
+function f_await_type(in ClientId p_client, in DHCP_Message_Types p_type)
+runs on DHCPv4_Server_MTC return DHCP_MSG
+{
+	var DHCP_MSG v_reply := f_await_reply();
+	var DHCP_Message_Types v_type := f_message_type(v_reply);
+
+	if (v_reply.xid != p_client.xid) {
+		setverdict(fail, "the reply carries transaction ", v_reply.xid,
+			   " rather than ", p_client.xid);
+		stop;
+	}
+
+	if (v_type != p_type) {
+		setverdict(fail, "the server sent ", v_type, " where ", p_type,
+			   " was called for");
+		stop;
+	}
+
+	return v_reply;
+}
+
+/* Everything a reply has to mirror from the message it answers. RFC 2131 4.1
+ * and table 3.
+ */
+function f_check_reply_shape(in ClientId p_client, in DHCP_MSG p_reply)
+runs on DHCPv4_Server_MTC
+{
+	if (p_reply.op != 2) {
+		setverdict(fail, "the reply has op ", p_reply.op, " rather than 2");
+	}
+	if (p_reply.htype != DHCP_HTYPE_Ethernet_10Mb) {
+		setverdict(fail, "the hardware type is ", p_reply.htype,
+			   " rather than ethernet");
+	}
+	if (p_reply.hlen != 6) {
+		setverdict(fail, "the hardware address length is ", p_reply.hlen,
+			   " rather than 6");
+	}
+	if (p_reply.chaddr != p_client.chaddr) {
+		setverdict(fail, "the reply carries hardware address ",
+			   p_reply.chaddr, " rather than ", p_client.chaddr);
+	}
+	if (p_reply.giaddr != c_addr_any) {
+		setverdict(fail, "the relay agent address is set in a reply to "&
+			   "a message that did not go through a relay");
+	}
+	if (not ispresent(p_reply.options)) {
+		setverdict(fail, "the reply carries no options at all");
+		return;
+	}
+	if (p_reply.options.magicCookie != c_magic_cookie) {
+		setverdict(fail, "the option field does not start with the magic cookie");
+	}
+	if (f_server_id(p_reply) != f_addr(tsp_sut_ipv4)) {
+		setverdict(fail, "the server identifies itself as ",
+			   f_server_id(p_reply), " rather than ", tsp_sut_ipv4);
+	}
+}
+
+/* Ask for an address and take the offer. Used by the tests that are about
+ * what happens to a lease once it exists.
+ */
+function f_take_a_lease(in ClientId p_client) runs on DHCPv4_Server_MTC return OCT4
+{
+	var DHCP_MSG v_offer;
+	var DHCP_MSG v_ack;
+
+	f_send_msg(f_client_msg(p_client, DHCP_Discover, c_addr_any, {}));
+	v_offer := f_await_type(p_client, DHCP_Offer);
+
+	f_send_msg(f_client_msg(p_client, DHCP_Request, c_addr_any,
+				{ f_opt_server_id(),
+				  f_opt_requested_ip(v_offer.yiaddr),
+				  f_opt_lease_time(tsp_lease_request) }));
+	v_ack := f_await_type(p_client, DHCP_Ack);
+
+	if (v_ack.yiaddr != v_offer.yiaddr) {
+		setverdict(fail, "the acknowledgement is for ", v_ack.yiaddr,
+			   " rather than the offered ", v_offer.yiaddr);
+		stop;
+	}
+
+	return v_ack.yiaddr;
+}
+
+/* A Discover has to be answered with an Offer of a free address from the
+ * pool, carrying what the client needs to accept it. RFC 2131 4.3.1.
+ */
+testcase tc_discover_is_offered_an_address() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(1);
+	var DHCP_MSG v_offer;
+
+	f_open();
+
+	f_send_msg(f_client_msg(v_client, DHCP_Discover, c_addr_any, {}));
+	v_offer := f_await_type(v_client, DHCP_Offer);
+
+	f_check_reply_shape(v_client, v_offer);
+
+	if (not f_in_pool(v_offer.yiaddr)) {
+		setverdict(fail, "the offered address ", v_offer.yiaddr,
+			   " is not one of the ", tsp_pool_size,
+			   " the server was given");
+	}
+	if (v_offer.ciaddr != c_addr_any) {
+		setverdict(fail, "the client address is set in an offer to a "&
+			   "client that has none");
+	}
+	if (f_lease_time(v_offer) <= 0) {
+		setverdict(fail, "the offer carries no lease time, so the client "&
+			   "does not know how long it may keep the address");
+	}
+
+	setverdict(pass);
+	f_close_all();
+}
+
+/* The request that accepts an offer is answered with an acknowledgement of
+ * the same address. RFC 2131 4.3.2, the Selecting case.
+ */
+testcase tc_request_completes_the_exchange() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(2);
+	var DHCP_MSG v_offer;
+	var DHCP_MSG v_ack;
+
+	f_open();
+
+	f_send_msg(f_client_msg(v_client, DHCP_Discover, c_addr_any, {}));
+	v_offer := f_await_type(v_client, DHCP_Offer);
+
+	f_send_msg(f_client_msg(v_client, DHCP_Request, c_addr_any,
+				{ f_opt_server_id(),
+				  f_opt_requested_ip(v_offer.yiaddr),
+				  f_opt_lease_time(tsp_lease_request) }));
+	v_ack := f_await_type(v_client, DHCP_Ack);
+
+	f_check_reply_shape(v_client, v_ack);
+
+	if (v_ack.yiaddr != v_offer.yiaddr) {
+		setverdict(fail, "the acknowledgement is for ", v_ack.yiaddr,
+			   " rather than the offered ", v_offer.yiaddr);
+	}
+	if (f_lease_time(v_ack) <= 0) {
+		setverdict(fail, "the acknowledgement carries no lease time");
+	}
+
+	setverdict(pass);
+	f_close_all();
+}
+
+/* A client that asks twice before accepting anything is offered the same
+ * address both times: the server has a binding for it by then, and RFC 2131
+ * 4.3.1 has that binding chosen first.
+ */
+testcase tc_the_same_client_is_offered_the_same_address() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(3);
+	var DHCP_MSG v_first;
+	var DHCP_MSG v_second;
+
+	f_open();
+
+	f_send_msg(f_client_msg(v_client, DHCP_Discover, c_addr_any, {}));
+	v_first := f_await_type(v_client, DHCP_Offer);
+
+	f_send_msg(f_client_msg(v_client, DHCP_Discover, c_addr_any, {}));
+	v_second := f_await_type(v_client, DHCP_Offer);
+
+	if (v_second.yiaddr != v_first.yiaddr) {
+		setverdict(fail, "the same client was offered ", v_first.yiaddr,
+			   " and then ", v_second.yiaddr);
+	} else {
+		setverdict(pass);
+	}
+
+	f_close_all();
+}
+
+/* Two clients are not offered the same address. An address that is spoken for
+ * is not free, and offering it twice would have the second client take an
+ * address the first is about to use.
+ */
+testcase tc_another_client_is_offered_another_address() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_first := f_client(4);
+	var ClientId v_second := f_client(5);
+	var DHCP_MSG v_offer_first;
+	var DHCP_MSG v_offer_second;
+
+	f_open();
+
+	f_send_msg(f_client_msg(v_first, DHCP_Discover, c_addr_any, {}));
+	v_offer_first := f_await_type(v_first, DHCP_Offer);
+
+	f_send_msg(f_client_msg(v_second, DHCP_Discover, c_addr_any, {}));
+	v_offer_second := f_await_type(v_second, DHCP_Offer);
+
+	if (v_offer_second.yiaddr == v_offer_first.yiaddr) {
+		setverdict(fail, "both clients were offered ", v_offer_first.yiaddr);
+	} else {
+		setverdict(pass);
+	}
+
+	f_close_all();
+}
+
+/* A client that comes back knowing the address it had asks for it without
+ * naming a server. The server that has the binding acknowledges it.
+ * RFC 2131 4.3.2, the Init-Reboot case.
+ */
+testcase tc_init_reboot_request_is_acknowledged() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(6);
+	var OCT4 v_leased;
+	var DHCP_MSG v_ack;
+
+	f_open();
+	v_leased := f_take_a_lease(v_client);
+
+	f_send_msg(f_client_msg(v_client, DHCP_Request, c_addr_any,
+				{ f_opt_requested_ip(v_leased) }));
+	v_ack := f_await_type(v_client, DHCP_Ack);
+
+	f_check_reply_shape(v_client, v_ack);
+
+	if (v_ack.yiaddr != v_leased) {
+		setverdict(fail, "the client was given ", v_ack.yiaddr,
+			   " rather than the ", v_leased, " it asked to keep");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close_all();
+}
+
+/* A client asking to keep an address that is not on this network has moved,
+ * and has to be told so rather than left waiting. RFC 2131 4.3.2 asks for a
+ * Nak, and for one message in reply to one message.
+ */
+testcase tc_request_from_another_subnet_is_refused() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(7);
+	var DHCP_MSG v_nak;
+
+	f_open();
+
+	f_send_msg(f_client_msg(v_client, DHCP_Request, c_addr_any,
+				{ f_opt_requested_ip(f_addr(tsp_foreign_address)) }));
+	v_nak := f_await_type(v_client, DHCP_Nak);
+
+	f_check_reply_shape(v_client, v_nak);
+
+	if (v_nak.yiaddr != c_addr_any) {
+		setverdict(fail, "a refusal carries the address ", v_nak.yiaddr,
+			   " where it should carry none");
+	}
+
+	/* One request, one reply. A client that is told no twice for the same
+	 * request has to work out that the second refusal is not the answer to
+	 * whatever it does next.
+	 */
+	f_expect_silence("a second refusal for a single request");
+
+	f_close_all();
+}
+
+/* An address that is given back is available again. The client that gave it
+ * back is no longer known, so asking to keep it is refused. RFC 2131 4.4.4.
+ */
+testcase tc_release_gives_the_address_back() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(8);
+	var OCT4 v_leased;
+	var DHCP_MSG v_nak;
+
+	f_open();
+	v_leased := f_take_a_lease(v_client);
+
+	f_send_msg(f_client_msg(v_client, DHCP_Release, v_leased,
+				{ f_opt_server_id() }));
+
+	/* A release is not answered. RFC 2131 table 3. */
+	f_expect_silence("a release, which nothing answers");
+
+	/* The binding is gone, so the address the client used to hold is no
+	 * longer its to keep.
+	 */
+	f_send_msg(f_client_msg(v_client, DHCP_Request, c_addr_any,
+				{ f_opt_requested_ip(v_leased) }));
+	v_nak := f_await_type(v_client, DHCP_Nak);
+	f_check_reply_shape(v_client, v_nak);
+
+	setverdict(pass);
+	f_close_all();
+}
+
+/* An address a client says is already in use must not be handed out again.
+ * RFC 2131 4.3.3.
+ */
+testcase tc_decline_takes_the_address_out_of_the_pool() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(9);
+	var DHCP_MSG v_first;
+	var DHCP_MSG v_second;
+
+	f_open();
+
+	f_send_msg(f_client_msg(v_client, DHCP_Discover, c_addr_any, {}));
+	v_first := f_await_type(v_client, DHCP_Offer);
+
+	f_send_msg(f_client_msg(v_client, DHCP_Decline, c_addr_any,
+				{ f_opt_server_id(),
+				  f_opt_requested_ip(v_first.yiaddr) }));
+
+	/* A decline is not answered either. */
+	f_expect_silence("a decline, which nothing answers");
+
+	f_send_msg(f_client_msg(v_client, DHCP_Discover, c_addr_any, {}));
+	v_second := f_await_type(v_client, DHCP_Offer);
+
+	if (v_second.yiaddr == v_first.yiaddr) {
+		setverdict(fail, "the server offered ", v_first.yiaddr,
+			   " again after being told it was already in use");
+	} else if (not f_in_pool(v_second.yiaddr)) {
+		setverdict(fail, "the replacement address ", v_second.yiaddr,
+			   " is not one of the ", tsp_pool_size,
+			   " the server was given");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close_all();
+}
+
+/* A client that configured its own address can still ask for the rest of the
+ * parameters. The answer carries no address and no lease, because none was
+ * given. RFC 2131 4.3.5.
+ */
+testcase tc_inform_is_answered_without_a_lease() runs on DHCPv4_Server_MTC
+{
+	var ClientId v_client := f_client(10);
+	var DHCP_MSG v_ack;
+
+	f_open();
+
+	/* The tester's own address, because the answer to an Inform goes to
+	 * the address the client says it already has.
+	 */
+	f_send_msg(f_client_msg(v_client, DHCP_Inform,
+				f_addr(tsp_tester_ipv4), {}));
+	v_ack := f_await_type(v_client, DHCP_Ack);
+
+	f_check_reply_shape(v_client, v_ack);
+
+	if (v_ack.yiaddr != c_addr_any) {
+		setverdict(fail, "the answer to an inform carries the address ",
+			   v_ack.yiaddr, " where it should carry none: nothing "&
+			   "was leased");
+	}
+	if (f_lease_time(v_ack) != -1) {
+		setverdict(fail, "the answer to an inform carries a lease time "&
+			   "of ", f_lease_time(v_ack), " for a lease that does "&
+			   "not exist");
+	}
+
+	setverdict(pass);
+	f_close_all();
+}
+
+control {
+	execute(tc_discover_is_offered_an_address());
+	execute(tc_request_completes_the_exchange());
+	execute(tc_the_same_client_is_offered_the_same_address());
+	execute(tc_another_client_is_offered_another_address());
+	execute(tc_init_reboot_request_is_acknowledged());
+	execute(tc_request_from_another_subnet_is_refused());
+	execute(tc_release_gives_the_address_back());
+	execute(tc_decline_takes_the_address_out_of_the_pool());
+	execute(tc_inform_is_answered_without_a_lease());
+}
+
+}

--- a/ttcn3/suites/dhcpv4_server/build.conf
+++ b/ttcn3/suites/dhcpv4_server/build.conf
@@ -1,0 +1,5 @@
+# The tester is the client, so it binds the port a DHCP client binds. Both
+# ports are written into RFC 2131 and neither can be moved, so this suite has
+# to be allowed a privileged port just as the client suite does. The harness
+# checks for that and skips the suite rather than failing when it cannot.
+PRIVILEGED=yes

--- a/ttcn3/suites/dhcpv4_server/dhcpv4_server.cfg
+++ b/ttcn3/suites/dhcpv4_server/dhcpv4_server.cfg
@@ -1,0 +1,36 @@
+# Runtime configuration for the DHCPv4 server conformance suite.
+#
+# The addresses below are the defaults that tests/net/conformance/dhcpv4_server
+# is built with, paired with the addresses net-setup.sh puts on zeth. Override
+# them here to run against a different link.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
+# The server probes an address with ICMP before offering it and waits a second
+# for an answer, so a reply is not immediate.
+Zephyr_SUT.tsp_response_timeout := 10.0
+Zephyr_SUT.tsp_silence_timeout := 2.0
+
+# Has to match POOL_BASE and CONFIG_NET_DHCPV4_SERVER_ADDR_COUNT in the system
+# under test.
+DHCPv4_Server_Suite.tsp_pool_base := "192.0.2.100"
+DHCPv4_Server_Suite.tsp_pool_size := 16
+DHCPv4_Server_Suite.tsp_foreign_address := "198.51.100.5"
+DHCPv4_Server_Suite.tsp_lease_request := 600
+
+# The tester binds a privileged port, so the whole run needs privilege.
+[TESTPORT_PARAMETERS]
+system.pt.broadcast := "enabled"
+
+[LOGGING]
+LogFile := "dhcpv4_server-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+DHCPv4_Server_Suite.control

--- a/ttcn3/suites/dhcpv4_server/sources.txt
+++ b/ttcn3/suites/dhcpv4_server/sources.txt
@@ -1,0 +1,6 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+
+titan.ProtocolModules.DHCP/src/DHCP_Options.ttcn
+titan.ProtocolModules.DHCP/src/DHCP_Types.ttcn
+titan.ProtocolModules.DHCP/src/DHCP_EncDec.cc

--- a/ttcn3/suites/dns/DNS_Suite.ttcn
+++ b/ttcn3/suites/dns/DNS_Suite.ttcn
@@ -32,6 +32,7 @@ import from IPL4asp_Types all;
 import from IPL4asp_PortType all;
 import from TCCConversion_Functions all;
 import from Zephyr_SUT all;
+import from Zephyr_Transport all;
 
 /* Where the tester listens. Not port 53: this needs no privileges, and it
  * cannot collide with a resolver already running on the host.
@@ -44,11 +45,7 @@ modulepar charstring tsp_query_name := "conformance.test";
 /* How many queries the tests that look at several of them collect. */
 modulepar integer tsp_query_sample := 5;
 
-type component DNS_MTC {
-	port IPL4asp_PT pt;
-	var ConnectionId v_connId := -1;
-	timer t_guard;
-}
+type component DNS_MTC extends Zephyr_Tester {}
 
 /* What a query looked like, kept apart from the message itself so that a test
  * can talk about where it came from.
@@ -63,26 +60,7 @@ type record of QuerySeen QueriesSeen;
 
 function f_open() runs on DNS_MTC
 {
-	var Result v_res;
-
-	map(mtc:pt, system:pt);
-
-	v_res := f_IPL4_listen(pt, tsp_tester_ipv4, tsp_dns_port, { udp := {} });
-	if (not ispresent(v_res.connId)) {
-		setverdict(fail, "cannot listen on ", tsp_tester_ipv4, ":", tsp_dns_port);
-		stop;
-	}
-
-	v_connId := v_res.connId;
-}
-
-function f_close() runs on DNS_MTC
-{
-	if (v_connId != -1) {
-		f_IPL4_close(pt, v_connId);
-		v_connId := -1;
-	}
-	unmap(mtc:pt, system:pt);
+	f_udp_listen(tsp_tester_ipv4, tsp_dns_port);
 }
 
 /* Wait for the next query. Fails the test case and stops it if the resolver
@@ -90,18 +68,7 @@ function f_close() runs on DNS_MTC
  */
 function f_await_query() runs on DNS_MTC return QuerySeen
 {
-	var ASP_RecvFrom v_recv;
-
-	t_guard.start(tsp_response_timeout);
-	alt {
-	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
-		t_guard.stop;
-	}
-	[] t_guard.timeout {
-		setverdict(fail, "no query within ", tsp_response_timeout, "s");
-		stop;
-	}
-	}
+	var ASP_RecvFrom v_recv := f_receive();
 
 	return { pdu := dec_PDU_DNS(v_recv.msg),
 		 fromAddr := v_recv.remName,
@@ -124,13 +91,7 @@ function f_await_queries(in integer p_count) runs on DNS_MTC return QueriesSeen
  */
 function f_reply_raw(in QuerySeen p_query, in octetstring p_msg) runs on DNS_MTC
 {
-	pt.send(ASP_SendTo:{
-		connId := v_connId,
-		remName := p_query.fromAddr,
-		remPort := p_query.fromPort,
-		proto := omit,
-		msg := p_msg
-	});
+	f_send_to(p_query.fromAddr, p_query.fromPort, p_msg);
 }
 
 /* A correct answer to p_query, carrying one A record for the queried name. */

--- a/ttcn3/suites/dns/DNS_Suite.ttcn
+++ b/ttcn3/suites/dns/DNS_Suite.ttcn
@@ -16,13 +16,6 @@
  * device and the next one follows, which is why the tests below talk about the
  * next query rather than a retry.
  *
- * One thing is deliberately not tested. RFC 5452 9.2 asks a resolver to vary
- * the source port between queries as well as the identifier, because the two
- * together are what an off path attacker has to guess. The resolver keeps one
- * socket per server, so its source port is fixed for as long as it runs. That
- * is worth knowing, but a test that asserted it would fail the day it was
- * improved, so it is recorded here rather than frozen into a test case.
- *
  * The system under test is tests/net/conformance/dns in the Zephyr tree.
  */
 module DNS_Suite {
@@ -223,6 +216,40 @@ testcase tc_query_id_varies() runs on DNS_MTC
 	f_close();
 }
 
+/* An off path attacker forging an answer has to guess the identifier and the
+ * source port together, so both have to move. A port that never changes is
+ * learned from any single query and is then no longer a guess. RFC 5452 9.2.
+ */
+testcase tc_query_source_port_varies() runs on DNS_MTC
+{
+	var QueriesSeen v_seen;
+	var integer v_repeats := 0;
+	var integer v_consecutive := 0;
+
+	f_open();
+	v_seen := f_await_queries(tsp_query_sample);
+
+	for (var integer i := 1; i < lengthof(v_seen); i := i + 1) {
+		if (v_seen[i].fromPort == v_seen[i - 1].fromPort) {
+			v_repeats := v_repeats + 1;
+		}
+		if (v_seen[i].fromPort == v_seen[i - 1].fromPort + 1) {
+			v_consecutive := v_consecutive + 1;
+		}
+	}
+
+	if (v_repeats == lengthof(v_seen) - 1) {
+		setverdict(fail, "every query leaves from the same port, so only "&
+			   "the identifier has to be guessed");
+	} else if (v_consecutive == lengthof(v_seen) - 1) {
+		setverdict(fail, "the source port counts up, so it is predictable");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
 /* A query that is never answered has to fail on its own and leave the
  * resolver able to ask again. This is the case that wedges a resolver which
  * loses track of a query slot.
@@ -348,6 +375,7 @@ testcase tc_answer_with_wrong_id_is_ignored() runs on DNS_MTC
 control {
 	execute(tc_query_is_well_formed());
 	execute(tc_query_id_varies());
+	execute(tc_query_source_port_varies());
 	execute(tc_unanswered_query_does_not_wedge());
 	execute(tc_answer_is_followed_by_more_queries());
 	execute(tc_malformed_answers_are_survived());

--- a/ttcn3/suites/dns/DNS_Suite.ttcn
+++ b/ttcn3/suites/dns/DNS_Suite.ttcn
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for the Zephyr DNS resolver.
+ *
+ * Here the roles are the other way round from the mDNS suite: the tester is
+ * the server, and what is under test is what the resolver puts on the wire and
+ * what it does with what comes back. The system under test asks for the same
+ * name over and over, so a test case can collect as many queries as it needs
+ * without having to trigger anything.
+ *
+ * The resolver does not retransmit. A query that goes unanswered fails on the
+ * device and the next one follows, which is why the tests below talk about the
+ * next query rather than a retry.
+ *
+ * One thing is deliberately not tested. RFC 5452 9.2 asks a resolver to vary
+ * the source port between queries as well as the identifier, because the two
+ * together are what an off path attacker has to guess. The resolver keeps one
+ * socket per server, so its source port is fixed for as long as it runs. That
+ * is worth knowing, but a test that asserted it would fail the day it was
+ * improved, so it is recorded here rather than frozen into a test case.
+ *
+ * The system under test is tests/net/conformance/dns in the Zephyr tree.
+ */
+module DNS_Suite {
+
+import from DNS_Types all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+
+/* Where the tester listens. Not port 53: this needs no privileges, and it
+ * cannot collide with a resolver already running on the host.
+ */
+modulepar integer tsp_dns_port := 15353;
+
+/* The name the system under test asks for. */
+modulepar charstring tsp_query_name := "conformance.test";
+
+/* How many queries the tests that look at several of them collect. */
+modulepar integer tsp_query_sample := 5;
+
+type component DNS_MTC {
+	port IPL4asp_PT pt;
+	var ConnectionId v_connId := -1;
+	timer t_guard;
+}
+
+/* What a query looked like, kept apart from the message itself so that a test
+ * can talk about where it came from.
+ */
+type record QuerySeen {
+	PDU_DNS pdu,
+	charstring fromAddr,
+	integer fromPort
+}
+
+type record of QuerySeen QueriesSeen;
+
+function f_open() runs on DNS_MTC
+{
+	var Result v_res;
+
+	map(mtc:pt, system:pt);
+
+	v_res := f_IPL4_listen(pt, tsp_tester_ipv4, tsp_dns_port, { udp := {} });
+	if (not ispresent(v_res.connId)) {
+		setverdict(fail, "cannot listen on ", tsp_tester_ipv4, ":", tsp_dns_port);
+		stop;
+	}
+
+	v_connId := v_res.connId;
+}
+
+function f_close() runs on DNS_MTC
+{
+	if (v_connId != -1) {
+		f_IPL4_close(pt, v_connId);
+		v_connId := -1;
+	}
+	unmap(mtc:pt, system:pt);
+}
+
+/* Wait for the next query. Fails the test case and stops it if the resolver
+ * has gone quiet, so callers can assume a value.
+ */
+function f_await_query() runs on DNS_MTC return QuerySeen
+{
+	var ASP_RecvFrom v_recv;
+
+	t_guard.start(tsp_response_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		t_guard.stop;
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "no query within ", tsp_response_timeout, "s");
+		stop;
+	}
+	}
+
+	return { pdu := dec_PDU_DNS(v_recv.msg),
+		 fromAddr := v_recv.remName,
+		 fromPort := v_recv.remPort };
+}
+
+function f_await_queries(in integer p_count) runs on DNS_MTC return QueriesSeen
+{
+	var QueriesSeen v_seen := {};
+
+	for (var integer i := 0; i < p_count; i := i + 1) {
+		v_seen[i] := f_await_query();
+	}
+
+	return v_seen;
+}
+
+/* Send raw octets back to whoever sent p_query. Used both for well formed
+ * answers and for the deliberately broken ones.
+ */
+function f_reply_raw(in QuerySeen p_query, in octetstring p_msg) runs on DNS_MTC
+{
+	pt.send(ASP_SendTo:{
+		connId := v_connId,
+		remName := p_query.fromAddr,
+		remPort := p_query.fromPort,
+		proto := omit,
+		msg := p_msg
+	});
+}
+
+/* A correct answer to p_query, carrying one A record for the queried name. */
+function f_answer(in QuerySeen p_query, in charstring p_addr) runs on DNS_MTC
+{
+	var octetstring v_rdata := f_convertIPAddrToBinary(p_addr);
+	var PDU_DNS v_rsp;
+
+	v_rsp := {
+		header := {
+			id := p_query.pdu.header.id,
+			qr := DNS_RESPONSE,
+			opCode := DNS_OP_QUERY,
+			aa := true,
+			tc := false,
+			rd := p_query.pdu.header.rd,
+			ra := true,
+			z := '000'B,
+			rCode := DNS_NO_ERROR,
+			qdCount := 1,
+			anCount := 1,
+			nsCount := 0,
+			arCount := 0
+		},
+		queries := p_query.pdu.queries,
+		answers := {
+			{
+				name := tsp_query_name,
+				rrType := DNS_A,
+				rrClass := DNS_IN,
+				ttl := int2oct(30, 4),
+				rdLength := lengthof(v_rdata),
+				rData := { a := v_rdata }
+			}
+		},
+		nameServerRecords := {},
+		additionalRecords := {}
+	};
+
+	f_reply_raw(p_query, enc_PDU_DNS(v_rsp, false, true));
+}
+
+function f_check_query_shape(in PDU_DNS p_query) runs on DNS_MTC
+{
+	if (p_query.header.qr != DNS_QUERY) {
+		setverdict(fail, "the query is marked as a response");
+	}
+	if (p_query.header.opCode != DNS_OP_QUERY) {
+		setverdict(fail, "opcode is ", p_query.header.opCode,
+			   " rather than a standard query");
+	}
+	if (not p_query.header.rd) {
+		setverdict(fail, "recursion desired is not set, so a recursive " &
+			   "server would not resolve the name");
+	}
+	if (p_query.header.qdCount != 1) {
+		setverdict(fail, "the query carries ", p_query.header.qdCount,
+			   " questions rather than one");
+	}
+	if (p_query.header.anCount != 0 or p_query.header.nsCount != 0 or
+	    p_query.header.arCount != 0) {
+		setverdict(fail, "the query carries records in a section that " &
+			   "should be empty");
+	}
+	if (lengthof(p_query.queries) != 1) {
+		setverdict(fail, "the question section does not hold one question");
+		return;
+	}
+	if (p_query.queries[0].qName != tsp_query_name) {
+		setverdict(fail, "the query asks for ", p_query.queries[0].qName,
+			   " rather than ", tsp_query_name);
+	}
+	if (p_query.queries[0].qType != DNS_A) {
+		setverdict(fail, "the query asks for type ",
+			   p_query.queries[0].qType, " rather than A");
+	}
+	if (p_query.queries[0].qClass != DNS_IN) {
+		setverdict(fail, "the query asks in class ",
+			   p_query.queries[0].qClass, " rather than IN");
+	}
+}
+
+/* A query has to say what it is asking, for whom, and leave the sections it
+ * is not using empty. RFC 1035 4.1.
+ */
+testcase tc_query_is_well_formed() runs on DNS_MTC
+{
+	var QuerySeen v_query;
+
+	f_open();
+	v_query := f_await_query();
+	f_check_query_shape(v_query.pdu);
+
+	setverdict(pass);
+	f_close();
+}
+
+/* The identifier is what stops an off path attacker from answering a query it
+ * cannot see, so it has to be unpredictable rather than a counter or a
+ * constant. RFC 5452 9.1.
+ */
+testcase tc_query_id_varies() runs on DNS_MTC
+{
+	var QueriesSeen v_seen;
+	var integer v_repeats := 0;
+	var integer v_consecutive := 0;
+
+	f_open();
+	v_seen := f_await_queries(tsp_query_sample);
+
+	for (var integer i := 1; i < lengthof(v_seen); i := i + 1) {
+		if (v_seen[i].pdu.header.id == v_seen[i - 1].pdu.header.id) {
+			v_repeats := v_repeats + 1;
+		}
+		if (v_seen[i].pdu.header.id ==
+		    v_seen[i - 1].pdu.header.id + 1) {
+			v_consecutive := v_consecutive + 1;
+		}
+	}
+
+	if (v_repeats == lengthof(v_seen) - 1) {
+		setverdict(fail, "every query carries the same identifier");
+	} else if (v_consecutive == lengthof(v_seen) - 1) {
+		setverdict(fail, "the identifier counts up, so it is predictable");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* A query that is never answered has to fail on its own and leave the
+ * resolver able to ask again. This is the case that wedges a resolver which
+ * loses track of a query slot.
+ */
+testcase tc_unanswered_query_does_not_wedge() runs on DNS_MTC
+{
+	var QuerySeen v_first;
+	var QuerySeen v_next;
+
+	f_open();
+	v_first := f_await_query();
+
+	/* Say nothing at all, and wait for the resolver to come back. */
+	v_next := f_await_query();
+	f_check_query_shape(v_next.pdu);
+
+	setverdict(pass);
+	f_close();
+}
+
+/* An answer has to be accepted without disturbing what follows. Asking again
+ * after one has been answered is what a resolver does when the answer has
+ * been used and released.
+ */
+testcase tc_answer_is_followed_by_more_queries() runs on DNS_MTC
+{
+	var QuerySeen v_query;
+	var QuerySeen v_next;
+
+	f_open();
+	v_query := f_await_query();
+	f_answer(v_query, tsp_sut_ipv4);
+
+	v_next := f_await_query();
+	f_check_query_shape(v_next.pdu);
+
+	if (v_next.pdu.header.id == v_query.pdu.header.id) {
+		setverdict(fail, "the query after an answered one reuses its identifier");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A resolver reads whatever the network hands it, so a broken response has to
+ * be dropped rather than trusted. Feed it several kinds and require that the
+ * resolver is still asking properly afterwards.
+ */
+testcase tc_malformed_answers_are_survived() runs on DNS_MTC
+{
+	var QuerySeen v_query;
+	var QuerySeen v_next;
+
+	f_open();
+
+	/* Shorter than a header. */
+	v_query := f_await_query();
+	f_reply_raw(v_query, '00'O);
+
+	/* A header that promises records which are not there. */
+	v_query := f_await_query();
+	f_reply_raw(v_query, int2oct(v_query.pdu.header.id, 2) &
+			     '8180'O & '0001000500000000'O);
+
+	/* A name whose label length runs off the end of the message. */
+	v_query := f_await_query();
+	f_reply_raw(v_query, int2oct(v_query.pdu.header.id, 2) &
+			     '8180'O & '0001000000000000'O & '3f4142'O);
+
+	/* A compression pointer that points at itself. */
+	v_query := f_await_query();
+	f_reply_raw(v_query, int2oct(v_query.pdu.header.id, 2) &
+			     '8180'O & '0001000100000000'O & 'c00c'O);
+
+	/* Still alive and still asking properly. */
+	v_next := f_await_query();
+	f_check_query_shape(v_next.pdu);
+
+	setverdict(pass);
+	f_close();
+}
+
+/* An answer carrying somebody else's identifier is an answer to a question
+ * this resolver did not ask, and has to be ignored. If it were accepted, the
+ * resolver would be trivially poisonable.
+ */
+testcase tc_answer_with_wrong_id_is_ignored() runs on DNS_MTC
+{
+	var QuerySeen v_query;
+	var QuerySeen v_next;
+	var PDU_DNS v_forged;
+
+	f_open();
+	v_query := f_await_query();
+
+	v_forged := v_query.pdu;
+	v_forged.header.id := (v_query.pdu.header.id + 1) mod 65536;
+	v_forged.header.qr := DNS_RESPONSE;
+	v_forged.header.aa := true;
+	v_forged.header.ra := true;
+	v_forged.header.anCount := 1;
+	v_forged.answers := {
+		{
+			name := tsp_query_name,
+			rrType := DNS_A,
+			rrClass := DNS_IN,
+			ttl := int2oct(30, 4),
+			rdLength := 4,
+			rData := { a := f_convertIPAddrToBinary("198.51.100.1") }
+		}
+	};
+
+	f_reply_raw(v_query, enc_PDU_DNS(v_forged, false, true));
+
+	/* The resolver has to carry on as though nothing had arrived. */
+	v_next := f_await_query();
+	f_check_query_shape(v_next.pdu);
+
+	setverdict(pass);
+	f_close();
+}
+
+control {
+	execute(tc_query_is_well_formed());
+	execute(tc_query_id_varies());
+	execute(tc_unanswered_query_does_not_wedge());
+	execute(tc_answer_is_followed_by_more_queries());
+	execute(tc_malformed_answers_are_survived());
+	execute(tc_answer_with_wrong_id_is_ignored());
+}
+
+}

--- a/ttcn3/suites/dns/dns.cfg
+++ b/ttcn3/suites/dns/dns.cfg
@@ -9,7 +9,9 @@ Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
 Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
 Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
 Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
-Zephyr_SUT.tsp_response_timeout := 5.0
+# The system under test waits out each lookup before starting the next, so a
+# query arrives every couple of seconds rather than continuously.
+Zephyr_SUT.tsp_response_timeout := 10.0
 Zephyr_SUT.tsp_silence_timeout := 2.0
 
 DNS_Suite.tsp_dns_port := 15353

--- a/ttcn3/suites/dns/dns.cfg
+++ b/ttcn3/suites/dns/dns.cfg
@@ -1,0 +1,27 @@
+# Runtime configuration for the DNS resolver conformance suite.
+#
+# The addresses below are the defaults that tests/net/conformance/dns is built
+# with, paired with the addresses net-setup.sh puts on zeth. Override them here
+# to run against a different link.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
+Zephyr_SUT.tsp_response_timeout := 5.0
+Zephyr_SUT.tsp_silence_timeout := 2.0
+
+DNS_Suite.tsp_dns_port := 15353
+DNS_Suite.tsp_query_name := "conformance.test"
+DNS_Suite.tsp_query_sample := 5
+
+[LOGGING]
+LogFile := "dns-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+DNS_Suite.control

--- a/ttcn3/suites/dns/sources.txt
+++ b/ttcn3/suites/dns/sources.txt
@@ -1,22 +1,5 @@
-# Module sources this suite builds against, relative to ../../modules.
-# One path per line; build.sh passes them to the makefile generator.
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
 
 titan.ProtocolModules.DNS/src/DNS_Types.ttcn
 titan.ProtocolModules.DNS/src/DNS_EncDec.cc
-
-titan.TestPorts.IPL4asp/src/IPL4asp_Types.ttcn
-titan.TestPorts.IPL4asp/src/IPL4asp_PortType.ttcn
-titan.TestPorts.IPL4asp/src/IPL4asp_Functions.ttcn
-titan.TestPorts.IPL4asp/src/IPL4asp_PT.cc
-titan.TestPorts.IPL4asp/src/IPL4asp_PT.hh
-titan.TestPorts.IPL4asp/src/IPL4asp_discovery.cc
-titan.TestPorts.IPL4asp/src/IPL4asp_protocol_L234.hh
-
-titan.TestPorts.Common_Components.Socket-API/src/Socket_API_Definitions.ttcn
-titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.cc
-titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.hh
-
-titan.Libraries.TCCUsefulFunctions/src/TCCConversion_Functions.ttcn
-titan.Libraries.TCCUsefulFunctions/src/TCCConversion.cc
-titan.Libraries.TCCUsefulFunctions/src/TCCInterface_Functions.ttcn
-titan.Libraries.TCCUsefulFunctions/src/TCCInterface.cc

--- a/ttcn3/suites/dns/sources.txt
+++ b/ttcn3/suites/dns/sources.txt
@@ -1,0 +1,22 @@
+# Module sources this suite builds against, relative to ../../modules.
+# One path per line; build.sh passes them to the makefile generator.
+
+titan.ProtocolModules.DNS/src/DNS_Types.ttcn
+titan.ProtocolModules.DNS/src/DNS_EncDec.cc
+
+titan.TestPorts.IPL4asp/src/IPL4asp_Types.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_PortType.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_Functions.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_PT.cc
+titan.TestPorts.IPL4asp/src/IPL4asp_PT.hh
+titan.TestPorts.IPL4asp/src/IPL4asp_discovery.cc
+titan.TestPorts.IPL4asp/src/IPL4asp_protocol_L234.hh
+
+titan.TestPorts.Common_Components.Socket-API/src/Socket_API_Definitions.ttcn
+titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.cc
+titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.hh
+
+titan.Libraries.TCCUsefulFunctions/src/TCCConversion_Functions.ttcn
+titan.Libraries.TCCUsefulFunctions/src/TCCConversion.cc
+titan.Libraries.TCCUsefulFunctions/src/TCCInterface_Functions.ttcn
+titan.Libraries.TCCUsefulFunctions/src/TCCInterface.cc

--- a/ttcn3/suites/dnssd/DNSSD_Suite.ttcn
+++ b/ttcn3/suites/dnssd/DNSSD_Suite.ttcn
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for Zephyr's DNS service discovery, RFC 6763.
+ *
+ * The tester asks the responder about the service the system under test
+ * advertises, and checks what comes back. Queries go to the multicast DNS
+ * group address, because the responder binds its socket to the group rather
+ * than to the wildcard address and so never sees a query addressed to it.
+ *
+ * The tester's own port is ephemeral rather than 5353, so every query here is
+ * a legacy unicast query in the sense of RFC 6762 6.7. The hostname side of
+ * the responder adapts its answer to one; the service discovery side does not,
+ * and that divergence is recorded in f_check_legacy_shape below rather than
+ * asserted away.
+ *
+ * The system under test is tests/net/conformance/dnssd in the Zephyr tree.
+ */
+module DNSSD_Suite {
+
+import from DNS_Types all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+import from Zephyr_Transport all;
+
+const charstring c_mdns_group_v4 := "224.0.0.251";
+const integer c_mdns_port := 5353;
+
+const RRClass c_class_in := 1;
+
+/* Bit 15 of the class field, which asks a multicast DNS cache to flush what
+ * it held for the name. RFC 6762 10.2.
+ */
+const RRClass c_class_in_flush := 32769;
+
+/* The life RFC 6762 6.7 gives an answer to a legacy unicast query, because
+ * whatever cached it may know nothing about multicast DNS.
+ */
+const integer c_mdns_legacy_ttl := 10;
+
+/* The service the system under test advertises. Has to match what its
+ * DNS_SD_REGISTER_TCP_SERVICE names and the port it is given.
+ */
+modulepar charstring tsp_service_type := "_zephyr._tcp.local";
+modulepar charstring tsp_service_instance := "zephyr._zephyr._tcp.local";
+modulepar integer tsp_service_port := 4242;
+
+/* Where a query for the list of service types goes. RFC 6763 9. */
+modulepar charstring tsp_enumeration_name := "_services._dns-sd._udp.local";
+
+/* A service type nothing on the link offers. */
+modulepar charstring tsp_unknown_service := "_nosuch._tcp.local";
+
+type component DNSSD_MTC extends Zephyr_Tester {}
+
+/* A query for one name and one type, as a resolver on the link would send it. */
+template PDU_DNS ts_query(charstring p_name, RRType p_type, integer p_id := 0) := {
+	header := {
+		id := p_id,
+		qr := DNS_QUERY,
+		opCode := DNS_OP_QUERY,
+		aa := false,
+		tc := false,
+		rd := false,
+		ra := false,
+		z := '000'B,
+		rCode := DNS_NO_ERROR,
+		qdCount := 1,
+		anCount := 0,
+		nsCount := 0,
+		arCount := 0
+	},
+	queries := { { qName := p_name, qType := p_type, qClass := DNS_IN } },
+	answers := {},
+	nameServerRecords := {},
+	additionalRecords := {}
+}
+
+function f_open() runs on DNSSD_MTC
+{
+	f_udp_listen(tsp_tester_ipv4);
+}
+
+function f_send_query(in charstring p_name, in RRType p_type,
+		      in integer p_id := 0)
+runs on DNSSD_MTC
+{
+	f_send_to(c_mdns_group_v4, c_mdns_port,
+		  enc_PDU_DNS(valueof(ts_query(p_name, p_type, p_id)), false, true));
+}
+
+/* Wait for an answer from the system under test.
+ *
+ * A query goes to the group address, so anything else on the link that speaks
+ * multicast DNS answers it too, and on a developer's machine there usually is
+ * something. Those answers are skipped rather than failed: they say nothing
+ * about the system under test either way.
+ */
+function f_await_response() runs on DNSSD_MTC return PDU_DNS
+{
+	var ASP_RecvFrom v_recv;
+
+	t_guard.start(tsp_response_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		if (v_recv.remName != tsp_sut_ipv4 and
+		    v_recv.remName != tsp_sut_ipv6) {
+			repeat;
+		}
+		t_guard.stop;
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "the system under test did not answer within ",
+			   tsp_response_timeout, "s");
+		stop;
+	}
+	}
+
+	return dec_PDU_DNS(v_recv.msg);
+}
+
+/* The other half: the system under test must not answer, whatever anything
+ * else on the link chooses to do.
+ */
+function f_expect_no_response(in charstring p_why) runs on DNSSD_MTC
+{
+	var ASP_RecvFrom v_recv;
+
+	t_guard.start(tsp_silence_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		if (v_recv.remName != tsp_sut_ipv4 and
+		    v_recv.remName != tsp_sut_ipv6) {
+			repeat;
+		}
+		t_guard.stop;
+		setverdict(fail, "answered when it should have stayed quiet: ",
+			   p_why);
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+/* An answer carries its records in more than one section: what was asked for
+ * goes in the answer section and what saves the asker a second lookup goes in
+ * the additional section, RFC 6763 12. A client reads both, so the tests look
+ * in both rather than fixing which section a record has to be in.
+ */
+function f_all_records(in PDU_DNS p_pdu) return ResourceRecords
+{
+	return p_pdu.answers & p_pdu.additionalRecords;
+}
+
+function f_find_record(in PDU_DNS p_pdu, in charstring p_name, in RRType p_type,
+		       out ResourceRecord p_rr) return boolean
+{
+	var ResourceRecords v_all := f_all_records(p_pdu);
+
+	for (var integer i := 0; i < lengthof(v_all); i := i + 1) {
+		if (v_all[i].name == p_name and v_all[i].rrType == p_type) {
+			p_rr := v_all[i];
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* A pointer record whose data is a given name, whatever else the answer
+ * carries. Both the list of service types and the list of instances of one
+ * type are pointer records, so both tests want this.
+ */
+function f_has_pointer_to(in PDU_DNS p_pdu, in charstring p_name,
+			  in charstring p_target) return boolean
+{
+	var ResourceRecords v_all := f_all_records(p_pdu);
+
+	for (var integer i := 0; i < lengthof(v_all); i := i + 1) {
+		if (v_all[i].name == p_name and v_all[i].rrType == DNS_PTR and
+		    ischosen(v_all[i].rData.ptr) and
+		    v_all[i].rData.ptr == p_target) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* The port a service record names.
+ *
+ * A record whose class carries the cache flush bit is not in a class the
+ * decoder knows, so it hands the data back undecoded, the same way the mDNS
+ * suite has to read an address. The layout is fixed by RFC 2782: priority,
+ * weight and port, two octets each, and then the target name.
+ */
+function f_srv_port(in ResourceRecord p_rr) runs on DNSSD_MTC return integer
+{
+	var octetstring v_data;
+
+	if (ischosen(p_rr.rData.srv)) {
+		return p_rr.rData.srv.portnum;
+	}
+
+	if (not ischosen(p_rr.rData.unsupported)) {
+		setverdict(fail, "the service record data is in neither form "&
+			   "this suite can read");
+		return -1;
+	}
+
+	v_data := p_rr.rData.unsupported;
+	if (lengthof(v_data) < 6) {
+		setverdict(fail, "the service record data is ", lengthof(v_data),
+			   " octets, too short to hold a port");
+		return -1;
+	}
+
+	return oct2int(substr(v_data, 4, 2));
+}
+
+/* What an answer to a legacy unicast query looks like today.
+ *
+ * RFC 6762 6.7 asks for an answer such a querier can read: the identifier it
+ * used echoed back, the question repeated, and a time to live short enough
+ * that a cache which knows nothing of multicast DNS does not hold the record
+ * for hours.
+ *
+ * The hostname side of the responder does all of that. The service discovery
+ * side builds its own messages and does none of it: it answers with the
+ * identifier zero, no question section, and the lifetimes it would have used
+ * for a multicast answer. Asserting the standard here would leave a test that
+ * fails until somebody fixes it, so what is asserted is what it does, and the
+ * divergence is recorded rather than lost. Each check says what would have to
+ * change with it.
+ *
+ * What it does get right, and what is checked as correct rather than recorded,
+ * is the cache flush bit: RFC 6763 12 keeps it clear on the pointer record,
+ * because several instances of a service share that name and an answer about
+ * one must not evict the others, and sets it on the records that belong to one
+ * instance alone.
+ */
+function f_check_legacy_shape(in PDU_DNS p_pdu, in integer p_id)
+runs on DNSSD_MTC
+{
+	var ResourceRecords v_all := f_all_records(p_pdu);
+
+	if (p_pdu.header.id == p_id and p_id != 0) {
+		setverdict(fail, "the answer now echoes the identifier of the "&
+			   "query, which RFC 6762 6.7 asks for and this suite "&
+			   "records as not happening: update the test and the "&
+			   "known gaps");
+	}
+	if (lengthof(p_pdu.queries) != 0) {
+		setverdict(fail, "the answer now repeats the question, which "&
+			   "RFC 6762 6.7 asks for and this suite records as not "&
+			   "happening: update the test and the known gaps");
+	}
+	if (lengthof(v_all) == 0) {
+		setverdict(fail, "the answer carries no records at all");
+		return;
+	}
+
+	for (var integer i := 0; i < lengthof(v_all); i := i + 1) {
+		if (oct2int(v_all[i].ttl) <= c_mdns_legacy_ttl) {
+			setverdict(fail, "a record now lives only ",
+				   oct2int(v_all[i].ttl), " seconds, which is "&
+				   "what RFC 6762 6.7 asks of an answer to a "&
+				   "legacy query and this suite records as not "&
+				   "happening: update the test and the known gaps");
+		}
+
+		if (v_all[i].rrType == DNS_PTR) {
+			if (v_all[i].rrClass != c_class_in) {
+				setverdict(fail, "the pointer record carries the "&
+					   "cache flush bit, which RFC 6763 12 "&
+					   "keeps clear because several instances "&
+					   "share that name");
+			}
+		} else if (v_all[i].rrClass != c_class_in_flush) {
+			setverdict(fail, "the record for ", v_all[i].name,
+				   " does not carry the cache flush bit, which "&
+				   "RFC 6763 12 asks for on a record belonging "&
+				   "to one instance");
+		}
+	}
+}
+
+/* Asking for the list of service types on the link names the one the system
+ * under test offers. RFC 6763 9.
+ */
+testcase tc_service_type_is_enumerated() runs on DNSSD_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open();
+
+	f_send_query(tsp_enumeration_name, DNS_PTR);
+	v_rsp := f_await_response();
+
+	if (not f_has_pointer_to(v_rsp, tsp_enumeration_name, tsp_service_type)) {
+		setverdict(fail, "the list of service types does not name ",
+			   tsp_service_type);
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* Asking about a service type names the instance of it. RFC 6763 4.1. */
+testcase tc_service_instance_is_named() runs on DNSSD_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open();
+
+	f_send_query(tsp_service_type, DNS_PTR);
+	v_rsp := f_await_response();
+
+	if (not f_has_pointer_to(v_rsp, tsp_service_type, tsp_service_instance)) {
+		setverdict(fail, "the answer does not name the instance ",
+			   tsp_service_instance);
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* The answer says where the service is, so that naming it was enough.
+ * RFC 6763 5 and 12.
+ */
+testcase tc_answer_carries_the_service_details() runs on DNSSD_MTC
+{
+	var PDU_DNS v_rsp;
+	var ResourceRecord v_srv;
+
+	f_open();
+
+	f_send_query(tsp_service_type, DNS_PTR);
+	v_rsp := f_await_response();
+
+	if (not f_find_record(v_rsp, tsp_service_instance, DNS_SRV, v_srv)) {
+		setverdict(fail, "the answer carries no service record for ",
+			   tsp_service_instance, ", so a client has to ask again "&
+			   "before it can connect");
+		f_close();
+		stop;
+	}
+
+	if (f_srv_port(v_srv) != tsp_service_port) {
+		setverdict(fail, "the service is at port ", f_srv_port(v_srv),
+			   " rather than ", tsp_service_port);
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A client that has resolved a service should not have to look up the host
+ * separately, so the address travels with the answer. RFC 6763 12.
+ */
+testcase tc_answer_carries_the_address() runs on DNSSD_MTC
+{
+	var PDU_DNS v_rsp;
+	var ResourceRecord v_a;
+
+	f_open();
+
+	f_send_query(tsp_service_type, DNS_PTR);
+	v_rsp := f_await_response();
+
+	if (not f_find_record(v_rsp, tsp_sut_hostname & ".local", DNS_A, v_a)) {
+		setverdict(fail, "the answer carries no address for ",
+			   tsp_sut_hostname & ".local", ", so resolving the "&
+			   "service took a second lookup");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* A service nothing on the link offers is not something to answer about. */
+testcase tc_unknown_service_is_ignored() runs on DNSSD_MTC
+{
+	f_open();
+
+	f_send_query(tsp_unknown_service, DNS_PTR);
+	f_expect_no_response("a query for a service type it does not offer");
+
+	f_close();
+}
+
+/* The answer to a legacy unicast query, as it is rather than as RFC 6762 6.7
+ * asks. See f_check_legacy_shape for why it is written this way round.
+ */
+testcase tc_legacy_query_answer_is_not_adapted() runs on DNSSD_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open();
+
+	f_send_query(tsp_service_type, DNS_PTR, 4660);
+	v_rsp := f_await_response();
+
+	f_check_legacy_shape(v_rsp, 4660);
+
+	setverdict(pass);
+	f_close();
+}
+
+control {
+	execute(tc_service_type_is_enumerated());
+	execute(tc_service_instance_is_named());
+	execute(tc_answer_carries_the_service_details());
+	execute(tc_answer_carries_the_address());
+	execute(tc_unknown_service_is_ignored());
+	execute(tc_legacy_query_answer_is_not_adapted());
+}
+
+}

--- a/ttcn3/suites/dnssd/dnssd.cfg
+++ b/ttcn3/suites/dnssd/dnssd.cfg
@@ -1,0 +1,29 @@
+# Runtime configuration for the DNS service discovery conformance suite.
+#
+# The service named here has to match the one tests/net/conformance/dnssd
+# registers, and the hostname has to match CONFIG_NET_HOSTNAME.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
+Zephyr_SUT.tsp_sut_hostname := "zephyr"
+Zephyr_SUT.tsp_response_timeout := 5.0
+Zephyr_SUT.tsp_silence_timeout := 2.0
+
+DNSSD_Suite.tsp_service_type := "_zephyr._tcp.local"
+DNSSD_Suite.tsp_service_instance := "zephyr._zephyr._tcp.local"
+DNSSD_Suite.tsp_service_port := 4242
+DNSSD_Suite.tsp_enumeration_name := "_services._dns-sd._udp.local"
+DNSSD_Suite.tsp_unknown_service := "_nosuch._tcp.local"
+
+[LOGGING]
+LogFile := "dnssd-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+DNSSD_Suite.control

--- a/ttcn3/suites/dnssd/sources.txt
+++ b/ttcn3/suites/dnssd/sources.txt
@@ -1,0 +1,5 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+
+titan.ProtocolModules.DNS/src/DNS_Types.ttcn
+titan.ProtocolModules.DNS/src/DNS_EncDec.cc

--- a/ttcn3/suites/mdns/MDNS_Suite.ttcn
+++ b/ttcn3/suites/mdns/MDNS_Suite.ttcn
@@ -36,6 +36,7 @@ import from IPL4asp_Types all;
 import from IPL4asp_PortType all;
 import from TCCConversion_Functions all;
 import from Zephyr_SUT all;
+import from Zephyr_Transport all;
 
 /* The responder answers with this TTL, RFC 6762 10 recommends it for records
  * that contain a host name.
@@ -60,11 +61,7 @@ function f_mdns_group_v6() return charstring
 	return c_mdns_group_v6 & "%" & tsp_tester_interface;
 }
 
-type component MDNS_MTC {
-	port IPL4asp_PT pt;
-	var ConnectionId v_connId := -1;
-	timer t_guard;
-}
+type component MDNS_MTC extends Zephyr_Tester {}
 
 /* A query for one name and one type, as a resolver on the link would send it. */
 template PDU_DNS ts_query(charstring p_name, RRType p_type) := {
@@ -89,44 +86,20 @@ template PDU_DNS ts_query(charstring p_name, RRType p_type) := {
 	additionalRecords := {}
 }
 
-/* Open an unconnected socket on the tester. It has to stay unconnected: the
- * query goes to the group address but the answer comes from the address of
- * the system under test, and a connected socket would discard it.
+/* The tester's port has to be an ephemeral one rather than 5353, so that the
+ * responder treats the query as a legacy unicast one and answers the tester
+ * alone. f_udp_listen defaults to that.
  */
 function f_open(in charstring p_local_addr) runs on MDNS_MTC
 {
-	var Result v_res;
-
-	map(mtc:pt, system:pt);
-
-	v_res := f_IPL4_listen(pt, p_local_addr, 0, { udp := {} });
-	if (not ispresent(v_res.connId)) {
-		setverdict(fail, "cannot open a socket on ", p_local_addr);
-		stop;
-	}
-
-	v_connId := v_res.connId;
-}
-
-function f_close() runs on MDNS_MTC
-{
-	if (v_connId != -1) {
-		f_IPL4_close(pt, v_connId);
-		v_connId := -1;
-	}
-	unmap(mtc:pt, system:pt);
+	f_udp_listen(p_local_addr);
 }
 
 function f_send_query(in charstring p_group, in charstring p_name, in RRType p_type)
 runs on MDNS_MTC
 {
-	pt.send(ASP_SendTo:{
-		connId := v_connId,
-		remName := p_group,
-		remPort := c_mdns_port,
-		proto := omit,
-		msg := enc_PDU_DNS(valueof(ts_query(p_name, p_type)), false, true)
-	});
+	f_send_to(p_group, c_mdns_port,
+		  enc_PDU_DNS(valueof(ts_query(p_name, p_type)), false, true));
 }
 
 /* Wait for one answer and hand back the decoded message. Fails the test case
@@ -134,18 +107,7 @@ runs on MDNS_MTC
  */
 function f_await_response() runs on MDNS_MTC return PDU_DNS
 {
-	var ASP_RecvFrom v_recv;
-
-	t_guard.start(tsp_response_timeout);
-	alt {
-	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
-		t_guard.stop;
-	}
-	[] t_guard.timeout {
-		setverdict(fail, "no answer within ", tsp_response_timeout, "s");
-		stop;
-	}
-	}
+	var ASP_RecvFrom v_recv := f_receive();
 
 	if (v_recv.remName != tsp_sut_ipv4 and v_recv.remName != tsp_sut_ipv6) {
 		setverdict(fail, "answer came from ", v_recv.remName,
@@ -153,25 +115,6 @@ function f_await_response() runs on MDNS_MTC return PDU_DNS
 	}
 
 	return dec_PDU_DNS(v_recv.msg);
-}
-
-/* Require that no answer arrives. Used where the responder is supposed to stay
- * quiet, which for mDNS is how a name it does not own is refused.
- */
-function f_await_silence() runs on MDNS_MTC
-{
-	var ASP_RecvFrom v_recv;
-
-	t_guard.start(tsp_silence_timeout);
-	alt {
-	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
-		t_guard.stop;
-		setverdict(fail, "answered a query it should have ignored");
-	}
-	[] t_guard.timeout {
-		setverdict(pass);
-	}
-	}
 }
 
 /* Every answer carries the queried name, the queried type, the cache flush
@@ -350,7 +293,7 @@ testcase tc_unknown_name_is_ignored() runs on MDNS_MTC
 {
 	f_open(tsp_tester_ipv4);
 	f_send_query(c_mdns_group_v4, "nosuchhost.local", DNS_A);
-	f_await_silence();
+	f_expect_silence("a name it does not own");
 	f_close();
 }
 
@@ -362,7 +305,7 @@ testcase tc_unknown_type_is_ignored() runs on MDNS_MTC
 {
 	f_open(tsp_tester_ipv4);
 	f_send_query(c_mdns_group_v4, f_local_name(), DNS_MX);
-	f_await_silence();
+	f_expect_silence("a type it has no record of");
 	f_close();
 }
 

--- a/ttcn3/suites/mdns/MDNS_Suite.ttcn
+++ b/ttcn3/suites/mdns/MDNS_Suite.ttcn
@@ -17,17 +17,11 @@
  * The system under test is samples/net/mdns_responder.
  *
  * Because the tester queries from an ephemeral port, every exchange here is a
- * legacy unicast query, and RFC 6762 6.7 asks for four things in the answer to
- * one of those: the query identifier echoed back, the question repeated, the
- * cache flush bit clear, and the TTL capped at ten seconds. The responder does
- * none of them, because it does not tell a legacy query apart from any other:
- * it answers with identifier zero, no question section, the cache flush bit
- * set and the full ten minute TTL. That is correct for the multicast answers
- * that a real mDNS resolver receives, since such a resolver queries from port
- * 5353. The tests below therefore check what the responder actually does, and
- * the two checks that encode a divergence are marked where they are made. If
- * the responder ever learns about legacy queries, those checks will fail and
- * should be changed deliberately rather than relaxed.
+ * legacy unicast query in the sense of RFC 6762 6.7: it comes from something
+ * making a one-off lookup rather than from another responder. The answer to
+ * one has to be something such a querier understands, which is what most of
+ * the checks below are about: the identifier it used echoed back, the question
+ * repeated, no cache flush bit, and a short time to live.
  */
 module MDNS_Suite {
 
@@ -38,15 +32,17 @@ import from TCCConversion_Functions all;
 import from Zephyr_SUT all;
 import from Zephyr_Transport all;
 
-/* The responder answers with this TTL, RFC 6762 10 recommends it for records
- * that contain a host name.
+/* An answer to a legacy unicast query may be cached by something that knows
+ * nothing about multicast DNS, so RFC 6762 6.7 keeps its life short.
  */
-const octetstring c_mdns_ttl := int2oct(600, 4);
+const octetstring c_mdns_legacy_ttl := int2oct(10, 4);
 
-/* Bit 15 of the class field of an answer asks the receiver to flush any
- * cached record with the same name and type, RFC 6762 10.2.
+/* Bit 15 of the class field asks a multicast DNS cache to flush what it held
+ * for the name. RFC 6762 10.2 keeps it clear in an answer to a legacy unicast
+ * query, whose recipient is not such a cache and would read the bit as part of
+ * the class.
  */
-const RRClass c_class_in_flush := 32769;
+const RRClass c_class_in := 1;
 
 const charstring c_mdns_group_v4 := "224.0.0.251";
 const charstring c_mdns_group_v6 := "ff02::fb";
@@ -64,9 +60,9 @@ function f_mdns_group_v6() return charstring
 type component MDNS_MTC extends Zephyr_Tester {}
 
 /* A query for one name and one type, as a resolver on the link would send it. */
-template PDU_DNS ts_query(charstring p_name, RRType p_type) := {
+template PDU_DNS ts_query(charstring p_name, RRType p_type, integer p_id := 0) := {
 	header := {
-		id := 0,
+		id := p_id,
 		qr := DNS_QUERY,
 		opCode := DNS_OP_QUERY,
 		aa := false,
@@ -95,11 +91,12 @@ function f_open(in charstring p_local_addr) runs on MDNS_MTC
 	f_udp_listen(p_local_addr);
 }
 
-function f_send_query(in charstring p_group, in charstring p_name, in RRType p_type)
+function f_send_query(in charstring p_group, in charstring p_name, in RRType p_type,
+		     in integer p_id := 0)
 runs on MDNS_MTC
 {
 	f_send_to(p_group, c_mdns_port,
-		  enc_PDU_DNS(valueof(ts_query(p_name, p_type)), false, true));
+		  enc_PDU_DNS(valueof(ts_query(p_name, p_type, p_id)), false, true));
 }
 
 /* Wait for one answer and hand back the decoded message. Fails the test case
@@ -117,12 +114,9 @@ function f_await_response() runs on MDNS_MTC return PDU_DNS
 	return dec_PDU_DNS(v_recv.msg);
 }
 
-/* Every answer carries the queried name, the queried type, the cache flush
- * bit and the host name TTL. Check that once, here, rather than in each test.
- *
- * The class and TTL checks encode the legacy unicast divergence described at
- * the top of this module: RFC 6762 6.7 wants the cache flush bit clear and the
- * TTL capped at ten seconds in an answer to a query from an ephemeral port.
+/* Every answer carries the queried name and type, the class without the cache
+ * flush bit, and the short time to live that RFC 6762 6.7 asks for. Check that
+ * once, here, rather than in each test.
  */
 function f_check_answer_shape(in ResourceRecord p_rr, in charstring p_name, in RRType p_type)
 runs on MDNS_MTC
@@ -133,12 +127,16 @@ runs on MDNS_MTC
 	if (p_rr.rrType != p_type) {
 		setverdict(fail, "answer has type ", p_rr.rrType, " rather than ", p_type);
 	}
-	if (p_rr.rrClass != c_class_in_flush) {
+	if (p_rr.rrClass != c_class_in) {
 		setverdict(fail, "answer class is ", p_rr.rrClass,
-			   " rather than IN with the cache flush bit set");
+			   " rather than IN; the cache flush bit does not belong "&
+			   "in an answer to a query from an ephemeral port");
 	}
-	if (p_rr.ttl != c_mdns_ttl) {
-		setverdict(fail, "answer TTL is ", p_rr.ttl, " rather than ", c_mdns_ttl);
+	if (p_rr.ttl != c_mdns_legacy_ttl) {
+		setverdict(fail, "answer TTL is ", p_rr.ttl, " rather than ",
+			   c_mdns_legacy_ttl, "; an answer that may be cached by "&
+			   "something that knows nothing of multicast DNS is "&
+			   "given a short life");
 	}
 }
 
@@ -336,6 +334,53 @@ testcase tc_multiple_answers_share_the_name() runs on MDNS_MTC
 	f_close();
 }
 
+/* A querier that asked from an ephemeral port is not a multicast DNS
+ * implementation and has no way to match an answer to its question except by
+ * the identifier it chose and the question coming back. RFC 6762 6.7.
+ */
+testcase tc_legacy_query_is_answered_conventionally() runs on MDNS_MTC
+{
+	const integer c_id := 4660;
+	var PDU_DNS v_rsp;
+
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, f_local_name(), DNS_A, c_id);
+	v_rsp := f_await_response();
+
+	if (v_rsp.header.id != c_id) {
+		setverdict(fail, "the answer carries identifier ", v_rsp.header.id,
+			   " rather than the ", c_id, " that was asked with, so "&
+			   "the querier cannot tell what it answers");
+	}
+
+	if (v_rsp.header.qdCount != 1 or lengthof(v_rsp.queries) != 1) {
+		setverdict(fail, "the answer does not repeat the question, so the "&
+			   "querier cannot tell what was asked");
+		f_close();
+		stop;
+	}
+
+	if (v_rsp.queries[0].qName != f_local_name()) {
+		setverdict(fail, "the repeated question asks about ",
+			   v_rsp.queries[0].qName, " rather than ", f_local_name());
+	}
+	if (v_rsp.queries[0].qType != DNS_A) {
+		setverdict(fail, "the repeated question has type ",
+			   v_rsp.queries[0].qType, " rather than A");
+	}
+	if (v_rsp.queries[0].qClass != c_class_in) {
+		setverdict(fail, "the repeated question has class ",
+			   v_rsp.queries[0].qClass, " rather than IN");
+	}
+
+	if (not f_has_a_record(v_rsp.answers, f_local_name(), tsp_sut_ipv4)) {
+		setverdict(fail, "no A record for ", f_local_name());
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
 /* The count in the header has to agree with what follows it, otherwise a
  * resolver either stops early or reads past the end of the message.
  */
@@ -366,6 +411,7 @@ control {
 	execute(tc_unknown_name_is_ignored());
 	execute(tc_unknown_type_is_ignored());
 	execute(tc_multiple_answers_share_the_name());
+	execute(tc_legacy_query_is_answered_conventionally());
 	execute(tc_answer_count_matches());
 }
 

--- a/ttcn3/suites/mdns/MDNS_Suite.ttcn
+++ b/ttcn3/suites/mdns/MDNS_Suite.ttcn
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for the Zephyr mDNS responder.
+ *
+ * The tester queries the responder and checks what comes back. Queries go to
+ * the mDNS group address, because the responder binds its socket to the group
+ * rather than to the wildcard address and so never sees a query addressed
+ * directly to it. The tester's own port is ephemeral rather than 5353, which
+ * makes each query a legacy unicast query in the sense of RFC 6762 6.7, so the
+ * answers come back to the tester alone and no multicast group membership is
+ * needed on this side.
+ *
+ * The system under test is samples/net/mdns_responder.
+ *
+ * Because the tester queries from an ephemeral port, every exchange here is a
+ * legacy unicast query, and RFC 6762 6.7 asks for four things in the answer to
+ * one of those: the query identifier echoed back, the question repeated, the
+ * cache flush bit clear, and the TTL capped at ten seconds. The responder does
+ * none of them, because it does not tell a legacy query apart from any other:
+ * it answers with identifier zero, no question section, the cache flush bit
+ * set and the full ten minute TTL. That is correct for the multicast answers
+ * that a real mDNS resolver receives, since such a resolver queries from port
+ * 5353. The tests below therefore check what the responder actually does, and
+ * the two checks that encode a divergence are marked where they are made. If
+ * the responder ever learns about legacy queries, those checks will fail and
+ * should be changed deliberately rather than relaxed.
+ */
+module MDNS_Suite {
+
+import from DNS_Types all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+
+/* The responder answers with this TTL, RFC 6762 10 recommends it for records
+ * that contain a host name.
+ */
+const octetstring c_mdns_ttl := int2oct(600, 4);
+
+/* Bit 15 of the class field of an answer asks the receiver to flush any
+ * cached record with the same name and type, RFC 6762 10.2.
+ */
+const RRClass c_class_in_flush := 32769;
+
+const charstring c_mdns_group_v4 := "224.0.0.251";
+const charstring c_mdns_group_v6 := "ff02::fb";
+const integer c_mdns_port := 5353;
+
+/* The IPv6 group is link local, so the address on its own does not say which
+ * link to send on. Naming the interface in the destination is what settles
+ * it; binding a source address is not enough.
+ */
+function f_mdns_group_v6() return charstring
+{
+	return c_mdns_group_v6 & "%" & tsp_tester_interface;
+}
+
+type component MDNS_MTC {
+	port IPL4asp_PT pt;
+	var ConnectionId v_connId := -1;
+	timer t_guard;
+}
+
+/* A query for one name and one type, as a resolver on the link would send it. */
+template PDU_DNS ts_query(charstring p_name, RRType p_type) := {
+	header := {
+		id := 0,
+		qr := DNS_QUERY,
+		opCode := DNS_OP_QUERY,
+		aa := false,
+		tc := false,
+		rd := false,
+		ra := false,
+		z := '000'B,
+		rCode := DNS_NO_ERROR,
+		qdCount := 1,
+		anCount := 0,
+		nsCount := 0,
+		arCount := 0
+	},
+	queries := { { qName := p_name, qType := p_type, qClass := DNS_IN } },
+	answers := {},
+	nameServerRecords := {},
+	additionalRecords := {}
+}
+
+/* Open an unconnected socket on the tester. It has to stay unconnected: the
+ * query goes to the group address but the answer comes from the address of
+ * the system under test, and a connected socket would discard it.
+ */
+function f_open(in charstring p_local_addr) runs on MDNS_MTC
+{
+	var Result v_res;
+
+	map(mtc:pt, system:pt);
+
+	v_res := f_IPL4_listen(pt, p_local_addr, 0, { udp := {} });
+	if (not ispresent(v_res.connId)) {
+		setverdict(fail, "cannot open a socket on ", p_local_addr);
+		stop;
+	}
+
+	v_connId := v_res.connId;
+}
+
+function f_close() runs on MDNS_MTC
+{
+	if (v_connId != -1) {
+		f_IPL4_close(pt, v_connId);
+		v_connId := -1;
+	}
+	unmap(mtc:pt, system:pt);
+}
+
+function f_send_query(in charstring p_group, in charstring p_name, in RRType p_type)
+runs on MDNS_MTC
+{
+	pt.send(ASP_SendTo:{
+		connId := v_connId,
+		remName := p_group,
+		remPort := c_mdns_port,
+		proto := omit,
+		msg := enc_PDU_DNS(valueof(ts_query(p_name, p_type)), false, true)
+	});
+}
+
+/* Wait for one answer and hand back the decoded message. Fails the test case
+ * and stops it if nothing arrives, so callers can assume a value.
+ */
+function f_await_response() runs on MDNS_MTC return PDU_DNS
+{
+	var ASP_RecvFrom v_recv;
+
+	t_guard.start(tsp_response_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		t_guard.stop;
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "no answer within ", tsp_response_timeout, "s");
+		stop;
+	}
+	}
+
+	if (v_recv.remName != tsp_sut_ipv4 and v_recv.remName != tsp_sut_ipv6) {
+		setverdict(fail, "answer came from ", v_recv.remName,
+			   " rather than from the system under test");
+	}
+
+	return dec_PDU_DNS(v_recv.msg);
+}
+
+/* Require that no answer arrives. Used where the responder is supposed to stay
+ * quiet, which for mDNS is how a name it does not own is refused.
+ */
+function f_await_silence() runs on MDNS_MTC
+{
+	var ASP_RecvFrom v_recv;
+
+	t_guard.start(tsp_silence_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		t_guard.stop;
+		setverdict(fail, "answered a query it should have ignored");
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+/* Every answer carries the queried name, the queried type, the cache flush
+ * bit and the host name TTL. Check that once, here, rather than in each test.
+ *
+ * The class and TTL checks encode the legacy unicast divergence described at
+ * the top of this module: RFC 6762 6.7 wants the cache flush bit clear and the
+ * TTL capped at ten seconds in an answer to a query from an ephemeral port.
+ */
+function f_check_answer_shape(in ResourceRecord p_rr, in charstring p_name, in RRType p_type)
+runs on MDNS_MTC
+{
+	if (p_rr.name != p_name) {
+		setverdict(fail, "answer names ", p_rr.name, " rather than ", p_name);
+	}
+	if (p_rr.rrType != p_type) {
+		setverdict(fail, "answer has type ", p_rr.rrType, " rather than ", p_type);
+	}
+	if (p_rr.rrClass != c_class_in_flush) {
+		setverdict(fail, "answer class is ", p_rr.rrClass,
+			   " rather than IN with the cache flush bit set");
+	}
+	if (p_rr.ttl != c_mdns_ttl) {
+		setverdict(fail, "answer TTL is ", p_rr.ttl, " rather than ", c_mdns_ttl);
+	}
+}
+
+/* The record data of an A or AAAA answer is the address either way, but a
+ * class with the cache flush bit set is not one the decoder recognises, so it
+ * hands the data back undecoded. Accept both forms.
+ */
+function f_rdata_address(in ResourceRecord p_rr) return octetstring
+{
+	if (ischosen(p_rr.rData.a)) {
+		return p_rr.rData.a;
+	}
+	if (ischosen(p_rr.rData.aaaa)) {
+		return p_rr.rData.aaaa;
+	}
+	if (ischosen(p_rr.rData.unsupported)) {
+		return p_rr.rData.unsupported;
+	}
+
+	return ''O;
+}
+
+/* True when the answers contain p_addr as an A record for p_name. */
+function f_has_a_record(in ResourceRecords p_rrs, in charstring p_name, in charstring p_addr)
+runs on MDNS_MTC return boolean
+{
+	var octetstring v_want := f_convertIPAddrToBinary(p_addr);
+
+	for (var integer i := 0; i < lengthof(p_rrs); i := i + 1) {
+		if (p_rrs[i].rrType != DNS_A) {
+			continue;
+		}
+		f_check_answer_shape(p_rrs[i], p_name, DNS_A);
+		if (f_rdata_address(p_rrs[i]) == v_want) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* True when the answers contain p_addr as an AAAA record for p_name. */
+function f_has_aaaa_record(in ResourceRecords p_rrs, in charstring p_name, in charstring p_addr)
+runs on MDNS_MTC return boolean
+{
+	var octetstring v_want := f_convertIPAddrToBinary(p_addr);
+
+	for (var integer i := 0; i < lengthof(p_rrs); i := i + 1) {
+		if (p_rrs[i].rrType != DNS_AAAA) {
+			continue;
+		}
+		f_check_answer_shape(p_rrs[i], p_name, DNS_AAAA);
+		if (f_rdata_address(p_rrs[i]) == v_want) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function f_local_name() return charstring
+{
+	return tsp_sut_hostname & ".local";
+}
+
+/* A query for the responder's own name over IPv4 is answered with its IPv4
+ * address.
+ */
+testcase tc_a_query() runs on MDNS_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, f_local_name(), DNS_A);
+	v_rsp := f_await_response();
+
+	if (v_rsp.header.qr != DNS_RESPONSE) {
+		setverdict(fail, "the answer is not marked as a response");
+	}
+	if (not v_rsp.header.aa) {
+		setverdict(fail, "the answer is not marked as authoritative");
+	}
+	if (lengthof(v_rsp.answers) < 1) {
+		setverdict(fail, "the answer carries no records");
+		f_close();
+		stop;
+	}
+	if (not f_has_a_record(v_rsp.answers, f_local_name(), tsp_sut_ipv4)) {
+		setverdict(fail, "no A record for ", f_local_name(),
+			   " holding ", tsp_sut_ipv4);
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A query for the responder's own name over IPv4 is answered with its IPv6
+ * addresses. The responder reports every address on the interface, so the
+ * link local one is there too; only the configured global address is
+ * required.
+ */
+testcase tc_aaaa_query() runs on MDNS_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, f_local_name(), DNS_AAAA);
+	v_rsp := f_await_response();
+
+	if (lengthof(v_rsp.answers) < 1) {
+		setverdict(fail, "the answer carries no records");
+		f_close();
+		stop;
+	}
+	if (not f_has_aaaa_record(v_rsp.answers, f_local_name(), tsp_sut_ipv6)) {
+		setverdict(fail, "no AAAA record for ", f_local_name(),
+			   " holding ", tsp_sut_ipv6);
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* The same exchange carried over IPv6 rather than IPv4. */
+testcase tc_aaaa_query_over_ipv6() runs on MDNS_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open(tsp_tester_ipv6);
+	f_send_query(f_mdns_group_v6(), f_local_name(), DNS_AAAA);
+	v_rsp := f_await_response();
+
+	if (lengthof(v_rsp.answers) < 1) {
+		setverdict(fail, "the answer carries no records");
+		f_close();
+		stop;
+	}
+	if (not f_has_aaaa_record(v_rsp.answers, f_local_name(), tsp_sut_ipv6)) {
+		setverdict(fail, "no AAAA record for ", f_local_name(),
+			   " holding ", tsp_sut_ipv6);
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A responder owns only its own names. RFC 6762 6 has it stay silent about
+ * anything else rather than answer with a name error, so that another
+ * responder on the link is free to claim the name.
+ */
+testcase tc_unknown_name_is_ignored() runs on MDNS_MTC
+{
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, "nosuchhost.local", DNS_A);
+	f_await_silence();
+	f_close();
+}
+
+/* A query for a type the responder has no record of is not answered either.
+ * The name is its own, so this separates "I do not own the name" from "I own
+ * the name but have nothing of that type".
+ */
+testcase tc_unknown_type_is_ignored() runs on MDNS_MTC
+{
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, f_local_name(), DNS_MX);
+	f_await_silence();
+	f_close();
+}
+
+/* More than one address of the same family is reported in one message, and
+ * every record after the first refers back to the name in the first rather
+ * than repeating it. Decoding the answer at all proves the back reference is
+ * well formed, since the decoder resolves it.
+ */
+testcase tc_multiple_answers_share_the_name() runs on MDNS_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, f_local_name(), DNS_AAAA);
+	v_rsp := f_await_response();
+
+	if (lengthof(v_rsp.answers) < 2) {
+		setverdict(pass, "only one address is configured, nothing to check");
+		f_close();
+		stop;
+	}
+
+	for (var integer i := 0; i < lengthof(v_rsp.answers); i := i + 1) {
+		f_check_answer_shape(v_rsp.answers[i], f_local_name(), DNS_AAAA);
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* The count in the header has to agree with what follows it, otherwise a
+ * resolver either stops early or reads past the end of the message.
+ */
+testcase tc_answer_count_matches() runs on MDNS_MTC
+{
+	var PDU_DNS v_rsp;
+
+	f_open(tsp_tester_ipv4);
+	f_send_query(c_mdns_group_v4, f_local_name(), DNS_A);
+	v_rsp := f_await_response();
+
+	if (v_rsp.header.anCount != lengthof(v_rsp.answers)) {
+		setverdict(fail, "header claims ", v_rsp.header.anCount,
+			   " answers but carries ", lengthof(v_rsp.answers));
+	}
+	if (v_rsp.header.nsCount != 0 or v_rsp.header.arCount != 0) {
+		setverdict(fail, "the answer carries unexpected extra sections");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+control {
+	execute(tc_a_query());
+	execute(tc_aaaa_query());
+	execute(tc_aaaa_query_over_ipv6());
+	execute(tc_unknown_name_is_ignored());
+	execute(tc_unknown_type_is_ignored());
+	execute(tc_multiple_answers_share_the_name());
+	execute(tc_answer_count_matches());
+}
+
+}

--- a/ttcn3/suites/mdns/mdns.cfg
+++ b/ttcn3/suites/mdns/mdns.cfg
@@ -1,0 +1,24 @@
+# Runtime configuration for the mDNS responder conformance suite.
+#
+# The addresses below are the defaults that samples/net/mdns_responder is
+# built with, paired with the addresses net-setup.sh puts on zeth. Override
+# them here to run against a different link.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
+Zephyr_SUT.tsp_sut_hostname := "zephyr"
+Zephyr_SUT.tsp_response_timeout := 5.0
+Zephyr_SUT.tsp_silence_timeout := 2.0
+
+[LOGGING]
+LogFile := "mdns-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+MDNS_Suite.control

--- a/ttcn3/suites/mdns/sources.txt
+++ b/ttcn3/suites/mdns/sources.txt
@@ -1,22 +1,5 @@
-# Module sources this suite builds against, relative to ../../modules.
-# One path per line; build.sh passes them to the makefile generator.
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
 
 titan.ProtocolModules.DNS/src/DNS_Types.ttcn
 titan.ProtocolModules.DNS/src/DNS_EncDec.cc
-
-titan.TestPorts.IPL4asp/src/IPL4asp_Types.ttcn
-titan.TestPorts.IPL4asp/src/IPL4asp_PortType.ttcn
-titan.TestPorts.IPL4asp/src/IPL4asp_Functions.ttcn
-titan.TestPorts.IPL4asp/src/IPL4asp_PT.cc
-titan.TestPorts.IPL4asp/src/IPL4asp_PT.hh
-titan.TestPorts.IPL4asp/src/IPL4asp_discovery.cc
-titan.TestPorts.IPL4asp/src/IPL4asp_protocol_L234.hh
-
-titan.TestPorts.Common_Components.Socket-API/src/Socket_API_Definitions.ttcn
-titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.cc
-titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.hh
-
-titan.Libraries.TCCUsefulFunctions/src/TCCConversion_Functions.ttcn
-titan.Libraries.TCCUsefulFunctions/src/TCCConversion.cc
-titan.Libraries.TCCUsefulFunctions/src/TCCInterface_Functions.ttcn
-titan.Libraries.TCCUsefulFunctions/src/TCCInterface.cc

--- a/ttcn3/suites/mdns/sources.txt
+++ b/ttcn3/suites/mdns/sources.txt
@@ -1,0 +1,22 @@
+# Module sources this suite builds against, relative to ../../modules.
+# One path per line; build.sh passes them to the makefile generator.
+
+titan.ProtocolModules.DNS/src/DNS_Types.ttcn
+titan.ProtocolModules.DNS/src/DNS_EncDec.cc
+
+titan.TestPorts.IPL4asp/src/IPL4asp_Types.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_PortType.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_Functions.ttcn
+titan.TestPorts.IPL4asp/src/IPL4asp_PT.cc
+titan.TestPorts.IPL4asp/src/IPL4asp_PT.hh
+titan.TestPorts.IPL4asp/src/IPL4asp_discovery.cc
+titan.TestPorts.IPL4asp/src/IPL4asp_protocol_L234.hh
+
+titan.TestPorts.Common_Components.Socket-API/src/Socket_API_Definitions.ttcn
+titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.cc
+titan.TestPorts.Common_Components.Abstract_Socket/src/Abstract_Socket.hh
+
+titan.Libraries.TCCUsefulFunctions/src/TCCConversion_Functions.ttcn
+titan.Libraries.TCCUsefulFunctions/src/TCCConversion.cc
+titan.Libraries.TCCUsefulFunctions/src/TCCInterface_Functions.ttcn
+titan.Libraries.TCCUsefulFunctions/src/TCCInterface.cc

--- a/ttcn3/suites/mqtt/MQTT_Suite.ttcn
+++ b/ttcn3/suites/mqtt/MQTT_Suite.ttcn
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for the Zephyr MQTT client, MQTT 3.1.1.
+ *
+ * The tester is the broker. It listens where a broker listens, takes the
+ * connection the client makes to it, and checks what arrives and what the
+ * client does with what it sends back.
+ *
+ * This is the first suite to work over a connection rather than over
+ * datagrams. Two things follow from that. The tester has to accept a
+ * connection before anything is said, which f_tcp_listen and f_tcp_accept in
+ * the shared layer do. And a connection is a stream with no message boundaries
+ * in it, so the port is told how to find the length of an MQTT message and
+ * hands whole messages up; the protocol module publishes the function for
+ * that, and f_open installs it.
+ *
+ * Each test case takes a connection of its own and closes it at the end. The
+ * system under test notices, waits a moment and connects again, so a test
+ * never inherits the state another one left. Nothing here depends on the order
+ * the tests run in.
+ *
+ * The system under test is tests/net/conformance/mqtt in the Zephyr tree.
+ */
+module MQTT_Suite {
+
+import from General_Types all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from MQTT_v3_1_1_Types all;
+import from MQTT_v3_1_1_IPL4SizeFunction all;
+import from Socket_API_Definitions all;
+import from Zephyr_SUT all;
+import from Zephyr_Transport all;
+
+/* Where a broker listens. Not a privileged port, so this suite needs no
+ * privilege either.
+ */
+modulepar integer tsp_broker_port := 1883;
+
+/* What the system under test is configured with. */
+modulepar charstring tsp_client_id := "zephyr-conformance";
+modulepar charstring tsp_topic := "zephyr/conformance";
+modulepar integer tsp_keep_alive := 5;
+
+/* How long to wait for a keep alive ping. A client pings after half the keep
+ * alive has passed with nothing to say, so this has to outlast that.
+ */
+modulepar float tsp_ping_timeout := 12.0;
+
+/* How many publishes the test that looks at several of them collects. */
+modulepar integer tsp_publish_sample := 3;
+
+/* Fixed by MQTT 3.1.1 section 3.1.2.1. */
+const charstring c_protocol_name := "MQTT";
+const integer c_protocol_level := 4;
+
+/* Connect return codes, MQTT 3.1.1 section 3.2.2.3. */
+const integer c_connack_accepted := 0;
+const integer c_connack_not_authorized := 5;
+
+type component MQTT_MTC extends Zephyr_Tester {}
+
+/* Listen, take the connection, and tell the port how to split the stream into
+ * messages. Without the length function the port would hand up whatever
+ * happened to arrive together, which is not the same as a message.
+ */
+function f_open() runs on MQTT_MTC
+{
+	var f_IPL4_getMsgLen v_length := refers(f_GetMsgLengthMQTT);
+
+	f_tcp_listen(tsp_tester_ipv4, tsp_broker_port);
+	f_tcp_accept();
+	f_IPL4_setGetMsgLen(pt, v_connId, v_length, {});
+}
+
+/* Wait for one message from the client. Fails the test case and stops it if
+ * nothing arrives or if what arrives is not a message, so callers can use the
+ * result without checking it first.
+ */
+function f_await_message(in float p_timeout := -1.0)
+runs on MQTT_MTC return MQTT_v3_1_1_ReqResp
+{
+	var ASP_RecvFrom v_recv := f_receive(p_timeout);
+	var MQTT_v3_1_1_Message v_msg;
+
+	if (f_MQTT_v3_1_1_dec(v_recv.msg, v_msg) != 0) {
+		setverdict(fail, "the client sent something that is not an "&
+			   "MQTT message: ", v_recv.msg);
+		stop;
+	}
+
+	if (not ischosen(v_msg.msg)) {
+		setverdict(fail, "the message did not decode into anything "&
+			   "the protocol knows");
+		stop;
+	}
+
+	return v_msg.msg;
+}
+
+function f_send_message(in MQTT_v3_1_1_ReqResp p_msg) runs on MQTT_MTC
+{
+	var octetstring v_bytes;
+
+	if (f_MQTT_v3_1_1_enc({ msg := p_msg }, v_bytes) != 0) {
+		setverdict(fail, "cannot encode a message to send");
+		stop;
+	}
+
+	f_send(v_bytes);
+}
+
+/* Wait for a message of one kind, letting anything else past. Used by the
+ * tests that are about one thing the client does among several.
+ */
+function f_await_publish(in float p_timeout := -1.0)
+runs on MQTT_MTC return MQTT_v3_1_1_Publish
+{
+	var MQTT_v3_1_1_ReqResp v_msg;
+
+	while (true) {
+		v_msg := f_await_message(p_timeout);
+		if (ischosen(v_msg.publish)) {
+			return v_msg.publish;
+		}
+	}
+
+	/* Not reached: f_await_message stops the test if nothing arrives. */
+	return { header := { dup_flag := '0'B,
+			     qos_level := AT_MOST_ONCE_DELIVERY,
+			     retain_flag := '0'B },
+		 topic_name := "",
+		 packet_identifier := omit,
+		 payload := ''O };
+}
+
+/* Require that nothing more is said on this connection.
+ *
+ * Scoped to the connection on purpose. The socket that was listening is still
+ * listening, so a client that gives up and connects again arrives on it, and
+ * that is a reasonable thing for it to do rather than an answer to anything.
+ */
+function f_expect_no_more(in charstring p_why) runs on MQTT_MTC
+{
+	var ASP_RecvFrom v_recv;
+	var IPL4asp_Types.ConnectionId v_this := v_connId;
+
+	t_guard.start(tsp_silence_timeout);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		if (v_recv.connId != v_this) {
+			repeat;
+		}
+		t_guard.stop;
+		setverdict(fail, "said more when it should have stopped: ",
+			   p_why);
+	}
+	[] pt.receive(ASP_Event:?) {
+		repeat;
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+/* The answer that lets a client get on with it, MQTT 3.1.1 section 3.2. */
+function f_connack(in integer p_code := c_connack_accepted)
+return MQTT_v3_1_1_ReqResp
+{
+	return { connack := {
+			header := { flags := '0000'B },
+			session_present_flag := '0'B,
+			connect_return_code := p_code } };
+}
+
+/* The acknowledgement of a publish sent at least once, section 3.4. */
+function f_puback(in integer p_identifier) return MQTT_v3_1_1_ReqResp
+{
+	return { puback := {
+			header := { flags := '0000'B },
+			packet_identifier := p_identifier } };
+}
+
+/* Take the connection and answer the connect, which is what every test but
+ * the two about connecting wants to have happened first.
+ */
+function f_connected() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_ReqResp v_msg;
+
+	f_open();
+
+	v_msg := f_await_message();
+	if (not ischosen(v_msg.connect_msg)) {
+		setverdict(fail, "the first message on a new connection was "&
+			   "not a connect");
+		stop;
+	}
+
+	f_send_message(f_connack());
+}
+
+/* A connect says which protocol it speaks, at which level, and who is
+ * speaking. MQTT 3.1.1 section 3.1.
+ */
+testcase tc_connect_is_well_formed() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_ReqResp v_msg;
+	var MQTT_v3_1_1_Connect v_connect;
+
+	f_open();
+
+	v_msg := f_await_message();
+	if (not ischosen(v_msg.connect_msg)) {
+		setverdict(fail, "the first message on a new connection was "&
+			   "not a connect");
+		f_tcp_close();
+		stop;
+	}
+
+	v_connect := v_msg.connect_msg;
+
+	if (v_connect.name != c_protocol_name) {
+		setverdict(fail, "the protocol name is ", v_connect.name,
+			   " rather than ", c_protocol_name);
+	}
+	if (v_connect.protocol_level != c_protocol_level) {
+		setverdict(fail, "the protocol level is ",
+			   v_connect.protocol_level, " rather than ",
+			   c_protocol_level, ", which is what 3.1.1 is");
+	}
+	if (v_connect.payload.client_identifier != tsp_client_id) {
+		setverdict(fail, "the client calls itself ",
+			   v_connect.payload.client_identifier, " rather than ",
+			   tsp_client_id);
+	}
+	if (v_connect.keep_alive != tsp_keep_alive) {
+		setverdict(fail, "the keep alive is ", v_connect.keep_alive,
+			   " rather than the configured ", tsp_keep_alive);
+	}
+
+	setverdict(pass);
+	f_tcp_close();
+}
+
+/* Until the broker has accepted the connection there is nothing to publish
+ * to, and a client that sends anyway is talking to a session that may never
+ * exist. MQTT 3.1.1 section 3.1.4.
+ */
+testcase tc_nothing_is_sent_before_the_connack() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_ReqResp v_msg;
+
+	f_open();
+
+	v_msg := f_await_message();
+	if (not ischosen(v_msg.connect_msg)) {
+		setverdict(fail, "the first message on a new connection was "&
+			   "not a connect");
+		f_tcp_close();
+		stop;
+	}
+
+	/* Say nothing, and see whether the client does. */
+	f_expect_no_more("a connect that has not been answered");
+
+	f_tcp_close();
+}
+
+/* A publish says what it is publishing and where, and carries an identifier
+ * when it is sent at least once, so that it can be acknowledged.
+ * MQTT 3.1.1 section 3.3.
+ */
+testcase tc_publish_is_well_formed() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_Publish v_publish;
+
+	f_connected();
+	v_publish := f_await_publish();
+
+	if (v_publish.topic_name != tsp_topic) {
+		setverdict(fail, "the publish is to ", v_publish.topic_name,
+			   " rather than ", tsp_topic);
+	}
+	if (v_publish.header.qos_level != AT_LEAST_ONCE_DELIVERY) {
+		setverdict(fail, "the publish is at quality ",
+			   v_publish.header.qos_level,
+			   " rather than at least once");
+	}
+	if (not ispresent(v_publish.packet_identifier)) {
+		setverdict(fail, "a publish sent at least once carries no "&
+			   "identifier, so there is nothing to acknowledge");
+	}
+	if (v_publish.header.dup_flag != '0'B) {
+		setverdict(fail, "the first publish is marked as a duplicate");
+	}
+
+	setverdict(pass);
+	f_tcp_close();
+}
+
+/* A message that has been acknowledged is finished with. Sending it again
+ * would have the broker deliver it twice, which is what the acknowledgement
+ * exists to prevent. MQTT 3.1.1 section 4.3.2.
+ *
+ * The other half of at least once delivery, re-sending a message that was
+ * never acknowledged, is not tested here. MQTT 3.1.1 asks for that only when a
+ * client reconnects to a session it left behind, and this client connects
+ * cleanly every time; while a connection is up, whether to re-send is left to
+ * whatever is doing the publishing.
+ */
+testcase tc_acknowledged_publish_is_not_repeated() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_Publish v_first;
+	var MQTT_v3_1_1_Publish v_next;
+	var boolean v_seen_again := false;
+
+	f_connected();
+
+	v_first := f_await_publish();
+	f_send_message(f_puback(v_first.packet_identifier));
+
+	for (var integer i := 0; i < tsp_publish_sample; i := i + 1) {
+		v_next := f_await_publish();
+		f_send_message(f_puback(v_next.packet_identifier));
+
+		if (v_next.packet_identifier == v_first.packet_identifier) {
+			v_seen_again := true;
+		}
+	}
+
+	if (v_seen_again) {
+		setverdict(fail, "identifier ", v_first.packet_identifier,
+			   " came back after it had been acknowledged");
+	} else {
+		setverdict(pass);
+	}
+
+	f_tcp_close();
+}
+
+/* Two messages in flight at once have to be told apart, so an identifier is
+ * not reused until the message that had it has been acknowledged.
+ * MQTT 3.1.1 section 2.3.1.
+ */
+testcase tc_packet_identifier_is_not_reused() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_Publish v_publish;
+	var integer v_previous := -1;
+	var integer v_repeats := 0;
+
+	f_connected();
+
+	for (var integer i := 0; i < tsp_publish_sample; i := i + 1) {
+		v_publish := f_await_publish();
+		f_send_message(f_puback(v_publish.packet_identifier));
+
+		if (v_publish.packet_identifier == v_previous) {
+			v_repeats := v_repeats + 1;
+		}
+
+		v_previous := v_publish.packet_identifier;
+	}
+
+	if (v_repeats > 0) {
+		setverdict(fail, v_repeats, " of ", tsp_publish_sample - 1,
+			   " publishes reuse the identifier of the one before, "&
+			   "which was acknowledged rather than lost");
+	} else {
+		setverdict(pass);
+	}
+
+	f_tcp_close();
+}
+
+/* A connection with nothing on it still has to be shown to be alive, or the
+ * broker is entitled to drop it. MQTT 3.1.1 section 3.1.2.10.
+ */
+testcase tc_keep_alive_is_sent_when_idle() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_ReqResp v_msg;
+	var boolean v_pinged := false;
+	var integer v_seen := 0;
+
+	f_connected();
+
+	/* Acknowledge the publishes so that the client has nothing outstanding
+	 * to send, and see whether a ping arrives among them.
+	 */
+	while (not v_pinged and v_seen < 20) {
+		v_msg := f_await_message(tsp_ping_timeout);
+		v_seen := v_seen + 1;
+
+		if (ischosen(v_msg.pingreq)) {
+			v_pinged := true;
+		} else if (ischosen(v_msg.publish)) {
+			f_send_message(f_puback(v_msg.publish.packet_identifier));
+		}
+	}
+
+	if (not v_pinged) {
+		setverdict(fail, "no ping in ", v_seen, " messages, so a broker "&
+			   "with nothing to say would have to guess whether the "&
+			   "client is still there");
+	} else {
+		setverdict(pass);
+	}
+
+	f_tcp_close();
+}
+
+/* A connect that is refused is not a connection. A client that publishes
+ * anyway is publishing into a session the broker has already said it will not
+ * open. MQTT 3.1.1 section 3.2.2.3.
+ */
+testcase tc_refused_connection_is_not_used() runs on MQTT_MTC
+{
+	var MQTT_v3_1_1_ReqResp v_msg;
+
+	f_open();
+
+	v_msg := f_await_message();
+	if (not ischosen(v_msg.connect_msg)) {
+		setverdict(fail, "the first message on a new connection was "&
+			   "not a connect");
+		f_tcp_close();
+		stop;
+	}
+
+	f_send_message(f_connack(c_connack_not_authorized));
+
+	f_expect_no_more("a connect that was refused");
+
+	f_tcp_close();
+}
+
+control {
+	execute(tc_connect_is_well_formed());
+	execute(tc_nothing_is_sent_before_the_connack());
+	execute(tc_publish_is_well_formed());
+	execute(tc_acknowledged_publish_is_not_repeated());
+	execute(tc_packet_identifier_is_not_reused());
+	execute(tc_keep_alive_is_sent_when_idle());
+	execute(tc_refused_connection_is_not_used());
+}
+
+}

--- a/ttcn3/suites/mqtt/mqtt.cfg
+++ b/ttcn3/suites/mqtt/mqtt.cfg
@@ -1,0 +1,29 @@
+# Runtime configuration for the MQTT client conformance suite.
+#
+# The client identifier, topic and keep alive have to match what
+# tests/net/conformance/mqtt is built with.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+# The system under test waits a second before connecting again, and publishes
+# every two, so nothing arrives immediately.
+Zephyr_SUT.tsp_response_timeout := 15.0
+Zephyr_SUT.tsp_silence_timeout := 3.0
+
+MQTT_Suite.tsp_broker_port := 1883
+MQTT_Suite.tsp_client_id := "zephyr-conformance"
+MQTT_Suite.tsp_topic := "zephyr/conformance"
+MQTT_Suite.tsp_keep_alive := 5
+MQTT_Suite.tsp_ping_timeout := 12.0
+MQTT_Suite.tsp_publish_sample := 3
+
+[LOGGING]
+LogFile := "mqtt-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+MQTT_Suite.control

--- a/ttcn3/suites/mqtt/sources.txt
+++ b/ttcn3/suites/mqtt/sources.txt
@@ -1,0 +1,8 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+
+titan.ProtocolModules.MQTT/src/MQTT_v3_1_1_Types.ttcn
+titan.ProtocolModules.MQTT/src/MQTT_v3_1_1_EncDec.cc
+# Splits the stream a connection carries into messages, see f_open.
+titan.ProtocolModules.MQTT/src/MQTT_v3_1_1_IPL4SizeFunction.ttcn
+titan.ProtocolModules.MQTT/src/MQTT_v3_1_1_Size.cc

--- a/ttcn3/suites/ndp/NDP_Suite.ttcn
+++ b/ttcn3/suites/ndp/NDP_Suite.ttcn
@@ -1,0 +1,734 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for Zephyr's IPv6 neighbour discovery, RFC 4861.
+ *
+ * The suite works below IP, so it reads and writes frames on the interface
+ * that has no address on the Linux side and has to be run as root. It builds
+ * its own ethernet, IPv6 and ICMPv6 headers, the same way the TCP suite does
+ * one protocol over.
+ *
+ * Only what the system under test does in answer to the tester is checked.
+ * What it does when it starts - the duplicate address detection for its own
+ * addresses, and the router solicitations that follow - is over before a suite
+ * can attach, so the one test here that watches an address being configured
+ * makes that happen by advertising a prefix rather than by waiting for a boot
+ * it cannot see.
+ *
+ * The application sends a datagram to the tester every couple of seconds, so
+ * an address the system under test cannot resolve keeps producing
+ * solicitations for the tests that examine those. Nothing else answers on this
+ * link, so a solicitation the suite does not answer stays unanswered.
+ *
+ * The system under test is tests/net/conformance/ndp in the Zephyr tree.
+ */
+module NDP_Suite {
+
+import from General_Types all;
+import from IP_Types all;
+import from NDP_Types all;
+import from Ethernet_Port all;
+import from Zephyr_SUT all;
+
+/* Has to match the source_address the ethernet port is configured with, so
+ * that what the tester claims in a message and what it sends from agree.
+ */
+modulepar charstring tsp_tester_mac := "020000000002";
+
+/* A link local address for the tester. An advertisement from a router is only
+ * accepted from one, RFC 4861 6.1.2.
+ */
+modulepar charstring tsp_tester_linklocal := "fe80::2";
+
+/* An address on the link that nothing holds, for the test that solicits one. */
+modulepar charstring tsp_unclaimed_ipv6 := "2001:db8::99";
+
+/* The prefix the tester advertises, and how long it says it lasts. */
+modulepar charstring tsp_advertised_prefix := "2001:db8:1::";
+modulepar integer tsp_prefix_lifetime := 600;
+
+/* Where the application sends its datagrams. */
+modulepar integer tsp_peer_port := 9999;
+
+const OCT2 c_ethertype_ipv6 := '86DD'O;
+
+/* IPv6 next header values. */
+const integer c_next_icmpv6 := 58;
+const integer c_next_udp := 17;
+
+/* ICMPv6 types that neighbour discovery uses, RFC 4861 4. */
+const integer c_type_router_solicitation := 133;
+const integer c_type_router_advertisement := 134;
+const integer c_type_neighbour_solicitation := 135;
+const integer c_type_neighbour_advertisement := 136;
+const integer c_type_redirect := 137;
+
+/* Everything neighbour discovery sends leaves with a hop limit of 255, and
+ * anything that arrives with less than that is discarded. That is what keeps
+ * the protocol on the link it belongs to. RFC 4861 7.1.1.
+ */
+const integer c_hop_limit := 255;
+
+const OCT16 c_addr_unspecified := '00000000000000000000000000000000'O;
+
+type component NDP_MTC {
+	port Ethernet_PT pt;
+	timer t_guard;
+	/* Learned from the first message the system under test sends. */
+	var OCT6 v_sut_mac := '000000000000'O;
+}
+
+/* A neighbour discovery message with the parts of the frame around it that
+ * the tests have something to say about.
+ */
+type record NdpSeen {
+	PDU_NDP pdu,
+	OCT16 src,
+	OCT16 dst,
+	OCT6 ethSrc,
+	OCT6 ethDst,
+	integer hopLimit
+}
+
+function f_mac(in charstring p_mac) return OCT6
+{
+	return str2oct(p_mac);
+}
+
+function f_ipv6(in charstring p_addr) return OCT16
+{
+	return f_IPv6_addr_enc(p_addr);
+}
+
+/* The solicited node multicast address of an address: ff02::1:ff and the last
+ * three octets of it. A node joins the group for each of its addresses, so
+ * that resolving one wakes only the node that holds it. RFC 4291 2.7.1.
+ */
+function f_solicited_node(in OCT16 p_addr) return OCT16
+{
+	return 'FF0200000000000000000001FF'O & substr(p_addr, 13, 3);
+}
+
+/* The ethernet address a multicast address is sent to: 33:33 and the last
+ * four octets. RFC 2464 7.
+ */
+function f_multicast_mac(in OCT16 p_addr) return OCT6
+{
+	return '3333'O & substr(p_addr, 12, 4);
+}
+
+/* All nodes on this link, where an advertisement goes when there is nobody in
+ * particular to send it to. RFC 4291 2.7.1.
+ */
+function f_all_nodes() return OCT16
+{
+	return f_ipv6("ff02::1");
+}
+
+function f_open() runs on NDP_MTC
+{
+	map(mtc:pt, system:pt);
+}
+
+function f_close() runs on NDP_MTC
+{
+	unmap(mtc:pt, system:pt);
+}
+
+/* Put a message on the link, wrapped in the headers it belongs in. The
+ * encoder works out the ICMPv6 checksum from the addresses it is given, which
+ * is why they are passed rather than taken from the packet.
+ */
+function f_send_ndp(in PDU_NDP p_pdu, in OCT16 p_src, in OCT16 p_dst,
+		    in OCT6 p_eth_dst, in integer p_hop_limit := c_hop_limit)
+runs on NDP_MTC
+{
+	var octetstring v_body := f_enc_PDU_NDP(p_pdu, p_src, p_dst);
+	var IPv6_packet v_ip;
+
+	v_ip := {
+		header := {
+			ver := 6,
+			trclass := 0,
+			flabel := 0,
+			plen := lengthof(v_body),
+			nexthead := c_next_icmpv6,
+			hlim := p_hop_limit,
+			srcaddr := p_src,
+			dstaddr := p_dst
+		},
+		ext_headers := omit,
+		payload := v_body
+	};
+
+	pt.send(Ethernet_Frame:{
+		destination := p_eth_dst,
+		source := f_mac(tsp_tester_mac),
+		etherType := c_ethertype_ipv6,
+		payload := f_IPv6_enc(v_ip)
+	});
+}
+
+/* Whether a frame carries a neighbour discovery message, and what of it the
+ * tests need. Everything else on the link - the datagrams the application
+ * sends, the multicast listener reports the stack sends - is not one.
+ */
+function f_as_ndp(in Ethernet_Frame p_frame, out NdpSeen p_seen) return boolean
+{
+	var IPv6_packet v_ip := f_IPv6_dec(p_frame.payload);
+	var integer v_type;
+
+	if (v_ip.header.nexthead != c_next_icmpv6) {
+		return false;
+	}
+
+	if (not ispresent(v_ip.payload) or lengthof(v_ip.payload) < 4) {
+		return false;
+	}
+
+	v_type := oct2int(substr(v_ip.payload, 0, 1));
+	if (v_type < c_type_router_solicitation or v_type > c_type_redirect) {
+		return false;
+	}
+
+	p_seen := {
+		pdu := f_dec_PDU_NDP(v_ip.payload),
+		src := v_ip.header.srcaddr,
+		dst := v_ip.header.dstaddr,
+		ethSrc := p_frame.source,
+		ethDst := p_frame.destination,
+		hopLimit := v_ip.header.hlim
+	};
+
+	return true;
+}
+
+/* Wait for a neighbour advertisement, ignoring everything else on the link.
+ * Fails the test case and stops it if none arrives, so callers can use the
+ * result without checking it first.
+ */
+function f_await_advertisement(in float p_timeout := -1.0)
+runs on NDP_MTC return NdpSeen
+{
+	var Ethernet_Frame v_frame;
+	var NdpSeen v_seen;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		if (f_as_ndp(v_frame, v_seen) and
+		    ischosen(v_seen.pdu.neighborAdvertisement)) {
+			t_guard.stop;
+			v_sut_mac := v_frame.source;
+		} else {
+			repeat;
+		}
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "no neighbour advertisement within ",
+			   v_timeout, "s");
+		stop;
+	}
+	}
+
+	return v_seen;
+}
+
+/* The other half: an advertisement that must not arrive. Only advertisements
+ * are looked at, because the application keeps talking on the link whatever
+ * the tester does, and none of that is an answer.
+ */
+function f_expect_no_advertisement(in charstring p_why) runs on NDP_MTC
+{
+	var Ethernet_Frame v_frame;
+	var NdpSeen v_seen;
+
+	t_guard.start(tsp_silence_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		if (f_as_ndp(v_frame, v_seen) and
+		    ischosen(v_seen.pdu.neighborAdvertisement)) {
+			t_guard.stop;
+			setverdict(fail, "answered when it should have stayed "&
+				   "quiet: ", p_why);
+		} else {
+			repeat;
+		}
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+/* Wait for a solicitation for a given address. */
+function f_await_solicitation(in OCT16 p_target, in float p_timeout := -1.0)
+runs on NDP_MTC return NdpSeen
+{
+	var Ethernet_Frame v_frame;
+	var NdpSeen v_seen;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		if (f_as_ndp(v_frame, v_seen) and
+		    ischosen(v_seen.pdu.neighborSolicitation) and
+		    v_seen.pdu.neighborSolicitation.targetAddress == p_target) {
+			t_guard.stop;
+			v_sut_mac := v_frame.source;
+		} else {
+			repeat;
+		}
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "no solicitation for ",
+			   f_IPv6_addr_dec(p_target), " within ", v_timeout, "s");
+		stop;
+	}
+	}
+
+	return v_seen;
+}
+
+/* Wait for a solicitation for any address inside a prefix, which is how an
+ * address the system under test has just given itself becomes visible.
+ */
+function f_await_solicitation_in_prefix(in OCT16 p_prefix, in integer p_octets,
+					in float p_timeout := -1.0)
+runs on NDP_MTC return NdpSeen
+{
+	var Ethernet_Frame v_frame;
+	var NdpSeen v_seen;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		if (f_as_ndp(v_frame, v_seen) and
+		    ischosen(v_seen.pdu.neighborSolicitation) and
+		    substr(v_seen.pdu.neighborSolicitation.targetAddress, 0,
+			   p_octets) == substr(p_prefix, 0, p_octets)) {
+			t_guard.stop;
+		} else {
+			repeat;
+		}
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "no address was configured from the prefix ",
+			   f_IPv6_addr_dec(p_prefix), " within ", v_timeout, "s");
+		stop;
+	}
+	}
+
+	return v_seen;
+}
+
+/* Wait for a datagram to the tester, which is what resolution was for. */
+function f_await_datagram(in float p_timeout := -1.0) runs on NDP_MTC
+{
+	var Ethernet_Frame v_frame;
+	var IPv6_packet v_ip;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		v_ip := f_IPv6_dec(v_frame.payload);
+		if (v_ip.header.nexthead == c_next_udp and
+		    v_ip.header.dstaddr == f_ipv6(tsp_tester_ipv6)) {
+			t_guard.stop;
+		} else {
+			repeat;
+		}
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "the datagram never followed the resolution, "&
+			   "so the advertisement was not taken");
+		stop;
+	}
+	}
+}
+
+/* A solicitation asking who holds an address. RFC 4861 4.3. */
+function f_solicitation(in OCT16 p_target, in boolean p_with_link_layer := true)
+return PDU_NDP
+{
+	var NSM_Options v_options := {};
+
+	if (p_with_link_layer) {
+		v_options := { { sourceLinkLayerAddress := {
+					optionType := 1,
+					lengthField := 0,
+					linkLayerAddrValue := f_mac(tsp_tester_mac) } } };
+	}
+
+	return { neighborSolicitation := {
+			typeField := c_type_neighbour_solicitation,
+			code := 0,
+			checksum := '0000'O,
+			reserved := '00000000'O,
+			targetAddress := p_target,
+			nSM_Options := v_options } };
+}
+
+/* An advertisement saying the tester holds an address. RFC 4861 4.4. */
+function f_advertisement(in OCT16 p_target) return PDU_NDP
+{
+	return { neighborAdvertisement := {
+			typeField := c_type_neighbour_advertisement,
+			code := 0,
+			checksum := '0000'O,
+			reserved1 := '00000'B,
+			oBit := '1'B,
+			sBit := '1'B,
+			rBit := '0'B,
+			reserved2 := '000000'O,
+			targetAddress := p_target,
+			nAM_Options := { { targetLinkLayerAddress := {
+						optionType := 2,
+						lengthField := 0,
+						linkLayerAddrValue :=
+							f_mac(tsp_tester_mac) } } } } };
+}
+
+/* A router advertisement carrying one prefix to configure an address from.
+ * RFC 4861 4.2, RFC 4862 5.5.3.
+ */
+function f_router_advertisement(in OCT16 p_prefix) return PDU_NDP
+{
+	return { routerAdvertisement := {
+			typeField := c_type_router_advertisement,
+			code := 0,
+			checksum := '0000'O,
+			curHopLimit := 64,
+			reserved := '000000'B,
+			oBit := '0'B,
+			mBit := '0'B,
+			routerLifetime := tsp_prefix_lifetime,
+			reachableTime := 0,
+			retransTimer := 0,
+			rAM_Options := {
+				{ sourceLinkLayerAddress := {
+					optionType := 1,
+					lengthField := 0,
+					linkLayerAddrValue := f_mac(tsp_tester_mac) } },
+				{ prefixInformation := {
+					optionType := 3,
+					lengthField := 4,
+					prefixLength := 64,
+					reserved1 := '000000'B,
+					aBit := '1'B,
+					lBit := '1'B,
+					validLifetime := tsp_prefix_lifetime,
+					preferredLifetime := tsp_prefix_lifetime,
+					reserved2 := '00000000'O,
+					prefix := p_prefix } } } } };
+}
+
+/* Everything an advertisement has to carry, whoever asked for it.
+ * RFC 4861 4.4 and 7.2.4.
+ */
+function f_check_advertisement(in NdpSeen p_seen, in OCT16 p_target)
+runs on NDP_MTC
+{
+	var NDP_NeighborAdvertisement v_na := p_seen.pdu.neighborAdvertisement;
+
+	if (v_na.targetAddress != p_target) {
+		setverdict(fail, "the advertisement is for ",
+			   f_IPv6_addr_dec(v_na.targetAddress), " rather than ",
+			   f_IPv6_addr_dec(p_target));
+	}
+	if (p_seen.hopLimit != c_hop_limit) {
+		setverdict(fail, "the advertisement left with hop limit ",
+			   p_seen.hopLimit, " rather than ", c_hop_limit,
+			   ", so a receiver has to discard it");
+	}
+	if (v_na.code != 0) {
+		setverdict(fail, "the code field is ", v_na.code,
+			   " rather than 0");
+	}
+	if (v_na.oBit != '1'B) {
+		setverdict(fail, "the override bit is clear, so a neighbour "&
+			   "that already had another address for this target "&
+			   "would keep it");
+	}
+	if (not ispresent(v_na.nAM_Options) or
+	    lengthof(v_na.nAM_Options) == 0) {
+		setverdict(fail, "the advertisement carries no target link "&
+			   "layer address, so it does not say where to send");
+		return;
+	}
+	if (substr(v_na.nAM_Options[0].targetLinkLayerAddress.linkLayerAddrValue,
+		   0, 6) != p_seen.ethSrc) {
+		setverdict(fail, "the target link layer address option and the "&
+			   "address the frame came from are different");
+	}
+}
+
+/* A solicitation for an address the system under test holds is answered, and
+ * the answer goes back to whoever asked. RFC 4861 7.2.4.
+ */
+testcase tc_solicitation_is_answered() runs on NDP_MTC
+{
+	var OCT16 v_target := f_ipv6(tsp_sut_ipv6);
+	var NdpSeen v_seen;
+
+	f_open();
+
+	f_send_ndp(f_solicitation(v_target), f_ipv6(tsp_tester_ipv6),
+		   f_solicited_node(v_target),
+		   f_multicast_mac(f_solicited_node(v_target)));
+
+	v_seen := f_await_advertisement();
+	f_check_advertisement(v_seen, v_target);
+
+	if (v_seen.pdu.neighborAdvertisement.sBit != '1'B) {
+		setverdict(fail, "the solicited bit is clear in an answer to a "&
+			   "solicitation, so the asker cannot treat it as one");
+	}
+	if (v_seen.dst != f_ipv6(tsp_tester_ipv6)) {
+		setverdict(fail, "the answer went to ",
+			   f_IPv6_addr_dec(v_seen.dst),
+			   " rather than back to the address that asked");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A solicitation for an address it does not hold is not its to answer. */
+testcase tc_solicitation_for_another_address_is_ignored() runs on NDP_MTC
+{
+	var OCT16 v_target := f_ipv6(tsp_unclaimed_ipv6);
+
+	f_open();
+
+	f_send_ndp(f_solicitation(v_target), f_ipv6(tsp_tester_ipv6),
+		   f_solicited_node(v_target),
+		   f_multicast_mac(f_solicited_node(v_target)));
+
+	f_expect_no_advertisement("a solicitation for an address it does not hold");
+
+	f_close();
+}
+
+/* A solicitation from the unspecified address is somebody else checking that
+ * an address is free before taking it. There is nowhere to send an answer, so
+ * the answer goes to every node on the link, and it is not solicited: nobody
+ * asked for it at an address. RFC 4861 7.2.4.
+ */
+testcase tc_solicitation_from_the_unspecified_address_is_multicast() runs on NDP_MTC
+{
+	var OCT16 v_target := f_ipv6(tsp_sut_ipv6);
+	var NdpSeen v_seen;
+
+	f_open();
+
+	/* No source link layer option: there is no source to describe, and one
+	 * here would make the message invalid. RFC 4861 7.1.1.
+	 */
+	f_send_ndp(f_solicitation(v_target, false), c_addr_unspecified,
+		   f_solicited_node(v_target),
+		   f_multicast_mac(f_solicited_node(v_target)));
+
+	v_seen := f_await_advertisement();
+	f_check_advertisement(v_seen, v_target);
+
+	if (v_seen.pdu.neighborAdvertisement.sBit != '0'B) {
+		setverdict(fail, "the solicited bit is set in an answer that "&
+			   "nobody can have solicited, because the solicitation "&
+			   "came from no address");
+	}
+	if (v_seen.dst != f_all_nodes()) {
+		setverdict(fail, "the answer went to ",
+			   f_IPv6_addr_dec(v_seen.dst),
+			   " rather than to every node on the link");
+	}
+	if (v_seen.ethDst != f_multicast_mac(f_all_nodes())) {
+		setverdict(fail, "the answer left to ", v_seen.ethDst,
+			   " rather than to the all nodes group address");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* Neighbour discovery is a conversation between nodes on one link, and the
+ * hop limit is what proves a message never crossed a router. Anything that
+ * arrives with less than 255 has, and has to be discarded. RFC 4861 7.1.1.
+ */
+testcase tc_solicitation_with_a_low_hop_limit_is_ignored() runs on NDP_MTC
+{
+	var OCT16 v_target := f_ipv6(tsp_sut_ipv6);
+
+	f_open();
+
+	f_send_ndp(f_solicitation(v_target), f_ipv6(tsp_tester_ipv6),
+		   f_solicited_node(v_target),
+		   f_multicast_mac(f_solicited_node(v_target)), 64);
+
+	f_expect_no_advertisement("a solicitation that reached the link with a "&
+				  "hop limit of 64, so it came through a router");
+
+	f_close();
+}
+
+/* A solicitation from the unspecified address that carries a source link
+ * layer address is contradicting itself, and is discarded rather than
+ * answered. RFC 4861 7.1.1.
+ */
+testcase tc_solicitation_from_nowhere_with_a_link_layer_address_is_ignored()
+runs on NDP_MTC
+{
+	var OCT16 v_target := f_ipv6(tsp_sut_ipv6);
+
+	f_open();
+
+	f_send_ndp(f_solicitation(v_target, true), c_addr_unspecified,
+		   f_solicited_node(v_target),
+		   f_multicast_mac(f_solicited_node(v_target)));
+
+	f_expect_no_advertisement("a solicitation from no address that still "&
+				  "says where to answer");
+
+	f_close();
+}
+
+/* Before sending to an address it has not resolved, a node asks who holds it.
+ * The application keeps sending, so the question keeps coming. RFC 4861 7.2.2.
+ */
+testcase tc_it_asks_before_it_sends() runs on NDP_MTC
+{
+	var OCT16 v_tester := f_ipv6(tsp_tester_ipv6);
+	var NdpSeen v_seen;
+	var NDP_NeighborSolicitation v_ns;
+
+	f_open();
+
+	v_seen := f_await_solicitation(v_tester);
+	v_ns := v_seen.pdu.neighborSolicitation;
+
+	if (v_seen.hopLimit != c_hop_limit) {
+		setverdict(fail, "the solicitation left with hop limit ",
+			   v_seen.hopLimit, " rather than ", c_hop_limit);
+	}
+	if (v_seen.dst != f_solicited_node(v_tester)) {
+		setverdict(fail, "the solicitation went to ",
+			   f_IPv6_addr_dec(v_seen.dst), " rather than to the "&
+			   "solicited node group of the address it is asking about");
+	}
+	if (v_seen.ethDst != f_multicast_mac(f_solicited_node(v_tester))) {
+		setverdict(fail, "the solicitation left to ", v_seen.ethDst,
+			   " rather than to the group address of that address");
+	}
+	if (v_ns.code != 0) {
+		setverdict(fail, "the code field is ", v_ns.code,
+			   " rather than 0");
+	}
+	if (not ispresent(v_ns.nSM_Options) or lengthof(v_ns.nSM_Options) == 0) {
+		setverdict(fail, "the solicitation carries no source link layer "&
+			   "address, so whoever answers has to ask in turn");
+	} else if (substr(v_ns.nSM_Options[0].sourceLinkLayerAddress.linkLayerAddrValue,
+			  0, 6) != v_seen.ethSrc) {
+		setverdict(fail, "the source link layer address option and the "&
+			   "address the frame came from are different");
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* Answering the question lets the datagram that was waiting on it through.
+ * RFC 4861 7.2.5.
+ */
+testcase tc_advertisement_completes_resolution() runs on NDP_MTC
+{
+	var OCT16 v_tester := f_ipv6(tsp_tester_ipv6);
+	var NdpSeen v_seen;
+
+	f_open();
+
+	v_seen := f_await_solicitation(v_tester);
+
+	f_send_ndp(f_advertisement(v_tester), v_tester, v_seen.src,
+		   v_seen.ethSrc);
+
+	f_await_datagram();
+
+	setverdict(pass);
+	f_close();
+}
+
+/* A prefix advertised by a router is one a host gives itself an address from,
+ * and it checks that the address is free before using it. RFC 4862 5.5.3.
+ */
+testcase tc_router_advertisement_is_acted_on() runs on NDP_MTC
+{
+	var OCT16 v_prefix := f_ipv6(tsp_advertised_prefix);
+	var NdpSeen v_seen;
+
+	f_open();
+
+	f_send_ndp(f_router_advertisement(v_prefix),
+		   f_ipv6(tsp_tester_linklocal), f_all_nodes(),
+		   f_multicast_mac(f_all_nodes()));
+
+	/* The address is new, so the first thing sent from it is the check
+	 * that nobody else has it, which comes from no address at all.
+	 */
+	v_seen := f_await_solicitation_in_prefix(v_prefix, 8);
+
+	if (v_seen.src != c_addr_unspecified) {
+		setverdict(fail, "the check that the new address is free came "&
+			   "from ", f_IPv6_addr_dec(v_seen.src),
+			   " rather than from no address, so it is not one");
+	}
+	if (v_seen.hopLimit != c_hop_limit) {
+		setverdict(fail, "the solicitation left with hop limit ",
+			   v_seen.hopLimit, " rather than ", c_hop_limit);
+	}
+
+	setverdict(pass);
+	f_close();
+}
+
+/* The two tests that watch the system under test resolve an address run first,
+ * and have to. A solicitation from the tester carries its own link layer
+ * address, which is enough for the system under test to remember it, and a
+ * remembered neighbour is confirmed by a unicast solicitation rather than
+ * resolved by a multicast one. Running them first is what keeps the tester
+ * unknown until they have finished.
+ */
+control {
+	execute(tc_it_asks_before_it_sends());
+	execute(tc_advertisement_completes_resolution());
+	execute(tc_solicitation_is_answered());
+	execute(tc_solicitation_for_another_address_is_ignored());
+	execute(tc_solicitation_from_the_unspecified_address_is_multicast());
+	execute(tc_solicitation_with_a_low_hop_limit_is_ignored());
+	execute(tc_solicitation_from_nowhere_with_a_link_layer_address_is_ignored());
+	execute(tc_router_advertisement_is_acted_on());
+}
+
+}

--- a/ttcn3/suites/ndp/build.conf
+++ b/ttcn3/suites/ndp/build.conf
@@ -1,0 +1,7 @@
+# The tester reads and writes ethernet frames directly, which needs a packet
+# socket, which needs privilege an ordinary user does not have.
+PRIVILEGED=yes
+
+# It works below the IP layer, so it uses the interface that has no address on
+# the Linux side rather than the one the socket suites share.
+L2=yes

--- a/ttcn3/suites/ndp/ndp.cfg
+++ b/ttcn3/suites/ndp/ndp.cfg
@@ -1,0 +1,39 @@
+# Runtime configuration for the IPv6 neighbour discovery conformance suite.
+#
+# The addresses below are the defaults that tests/net/conformance/ndp is built
+# with. The interface is the one with no address on the Linux side, so that
+# nothing but the tester answers on it.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
+Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
+# The application sends to the tester every two seconds, so a solicitation is
+# never far away, but an address it has given up on is retried more slowly.
+Zephyr_SUT.tsp_response_timeout := 15.0
+Zephyr_SUT.tsp_silence_timeout := 3.0
+
+NDP_Suite.tsp_tester_mac := "020000000002"
+NDP_Suite.tsp_tester_linklocal := "fe80::2"
+NDP_Suite.tsp_unclaimed_ipv6 := "2001:db8::99"
+NDP_Suite.tsp_advertised_prefix := "2001:db8:1::"
+NDP_Suite.tsp_prefix_lifetime := 600
+NDP_Suite.tsp_peer_port := 9999
+
+[TESTPORT_PARAMETERS]
+# The port opens the interface when the port is mapped, so it reads all of
+# this for itself before any test code runs.
+system.pt.interface := "zethL2"
+system.pt.source_address := "020000000002"
+# Only IPv6 reaches the tests. There is no address resolution to answer on
+# this link, because the system under test runs no IPv4.
+system.pt.ethertype := "86DD"
+
+[LOGGING]
+LogFile := "ndp-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+NDP_Suite.control

--- a/ttcn3/suites/ndp/sources.txt
+++ b/ttcn3/suites/ndp/sources.txt
@@ -1,0 +1,7 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+
+titan.ProtocolModules.NDP/src/NDP_Types.ttcn
+titan.ProtocolModules.NDP/src/NDP_EncDec.cc
+titan.ProtocolModules.IP/src/IP_Types.ttcn
+titan.ProtocolModules.IP/src/IP_EncDec.cc

--- a/ttcn3/suites/sntp/SNTP_Suite.ttcn
+++ b/ttcn3/suites/sntp/SNTP_Suite.ttcn
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for the Zephyr SNTP client, RFC 4330.
+ *
+ * The tester is the time server. What is under test is the request the client
+ * puts on the wire, and which replies it is willing to take the time from.
+ *
+ * The second half of that is the interesting half, and it is visible from
+ * outside because the system under test does what an SNTP client is for: it
+ * sets the system clock from the answer. Zephyr stamps every request with the
+ * current real time, so the next request after a reply says whether the reply
+ * was accepted - it carries the offered time if it was, and the old time if it
+ * was not. No channel into the device is needed to see it.
+ *
+ * Each test that examines a rejection first synchronises the clock to a time of
+ * its own, so that it can then offer a different one and show that the clock
+ * did not move to it. That makes the tests independent of each other and of
+ * the order they run in, and it costs one extra exchange.
+ *
+ * The system under test is tests/net/conformance/sntp in the Zephyr tree.
+ */
+module SNTP_Suite {
+
+import from General_Types all;
+import from IPL4asp_Types all;
+import from IPL4asp_PortType all;
+import from SNTP_Types all;
+import from Zephyr_SUT all;
+import from Zephyr_Transport all;
+
+/* Where the tester listens. Not port 123: this needs no privileges, and it
+ * cannot collide with a time daemon already running on the host.
+ */
+modulepar integer tsp_sntp_port := 12123;
+
+/* How many requests the test that looks at several of them collects. */
+modulepar integer tsp_request_sample := 4;
+
+/* How far the clock in a request may be from the time that was offered for it
+ * to count as having been accepted. It only has to cover the round trip and
+ * the interval the client waits between queries.
+ */
+modulepar integer tsp_clock_tolerance := 60;
+
+/* The times the tests offer, as seconds since the POSIX epoch. They are years
+ * apart so that a clock which did not move is unmistakable, and each test uses
+ * one of its own so that nothing carries over from the test before.
+ *
+ *   3786825600 NTP = 2020-01-01, 3644956800 = 2015-07-04,
+ *   3529958400 NTP = 2011-11-11, 3427142400 = 2008-08-08,
+ *   3324240000 NTP = 2005-05-05
+ */
+modulepar integer tsp_time_accepted := 1577836800;
+modulepar integer tsp_time_originate := 1435968000;
+modulepar integer tsp_time_mode := 1320969600;
+modulepar integer tsp_time_kod := 1218153600;
+modulepar integer tsp_time_truncated := 1115251200;
+
+/* How long to watch for retransmissions. It has to outlast one query, which
+ * the client gives up on after its own timeout, but not so much that the
+ * queries which follow are counted as retransmissions of it.
+ */
+modulepar float tsp_backoff_window := 2.5;
+
+/* How many requests that window has to hold for the client to be
+ * retransmitting rather than merely asking again on its own schedule.
+ */
+modulepar integer tsp_backoff_minimum := 3;
+
+type component SNTP_MTC extends Zephyr_Tester {}
+
+/* A request, kept with where it came from so that a reply can be addressed,
+ * and with the octets as they arrived so that the length can be checked.
+ */
+type record RequestSeen {
+	SNTP_Packet pkt,
+	octetstring raw,
+	charstring fromAddr,
+	integer fromPort
+}
+
+type record of RequestSeen RequestsSeen;
+
+function f_open() runs on SNTP_MTC
+{
+	f_udp_listen(tsp_tester_ipv4, tsp_sntp_port);
+}
+
+function f_abs(in integer p_value) return integer
+{
+	if (p_value < 0) {
+		return -p_value;
+	}
+
+	return p_value;
+}
+
+/* A timestamp on the wire counts from 1900, the clock the tests talk about
+ * counts from 1970.
+ */
+function f_ntp_seconds(in integer p_unix) return integer
+{
+	return p_unix + c_ntp_epoch_offset;
+}
+
+/* Wait for the next request. Fails the test case and stops it if the client
+ * has gone quiet or has sent something that is not a message at all, so
+ * callers can assume a value.
+ */
+function f_await_request() runs on SNTP_MTC return RequestSeen
+{
+	var ASP_RecvFrom v_recv := f_receive();
+	var bitstring v_bits;
+	var SNTP_Packet v_pkt;
+
+	if (lengthof(v_recv.msg) != c_sntp_packet_length) {
+		setverdict(fail, "a request is ", lengthof(v_recv.msg),
+			   " octets rather than ", c_sntp_packet_length);
+		stop;
+	}
+
+	v_bits := oct2bit(v_recv.msg);
+	if (decvalue(v_bits, v_pkt) != 0) {
+		setverdict(fail, "a request of the right length did not decode "&
+			   "as a message: ", v_recv.msg);
+		stop;
+	}
+
+	return { pkt := v_pkt,
+		 raw := v_recv.msg,
+		 fromAddr := v_recv.remName,
+		 fromPort := v_recv.remPort };
+}
+
+function f_await_requests(in integer p_count) runs on SNTP_MTC return RequestsSeen
+{
+	var RequestsSeen v_seen := {};
+
+	for (var integer i := 0; i < p_count; i := i + 1) {
+		v_seen[i] := f_await_request();
+	}
+
+	return v_seen;
+}
+
+/* Count what arrives over a window without looking at any of it. Used by the
+ * one test that is about how often the client asks rather than what it asks.
+ */
+function f_count_requests(in float p_window) runs on SNTP_MTC return integer
+{
+	var ASP_RecvFrom v_recv;
+	var integer v_count := 0;
+
+	t_guard.start(p_window);
+	alt {
+	[] pt.receive(ASP_RecvFrom:?) -> value v_recv {
+		v_count := v_count + 1;
+		repeat;
+	}
+	[] t_guard.timeout {
+	}
+	}
+
+	return v_count;
+}
+
+/* A reply that a client has every reason to believe: mode 4, a stratum, the
+ * version and poll interval copied back from the request, and the request's
+ * transmit timestamp returned as the originate timestamp. RFC 4330 section 6.
+ */
+function f_good_reply(in RequestSeen p_req, in integer p_unix) return SNTP_Packet
+{
+	var OCT4 v_seconds := int2oct(f_ntp_seconds(p_unix), 4);
+
+	return {
+		li := c_sntp_li_none,
+		vn := p_req.pkt.vn,
+		mode := c_sntp_mode_server,
+		stratum := c_sntp_stratum_primary,
+		poll := p_req.pkt.poll,
+		/* 2^-20 seconds, about a microsecond. */
+		precision := 'EC'O,
+		rootDelay := c_sntp_zero_word,
+		/* 16.16 fixed point seconds, so about four milliseconds. */
+		rootDispersion := '00000100'O,
+		/* A stratum one server names its reference clock here. "LOCL"
+		 * is the one for an undisciplined local clock, which is what
+		 * this is.
+		 */
+		referenceId := '4C4F434C'O,
+		referenceSeconds := v_seconds,
+		referenceFraction := c_sntp_zero_word,
+		originateSeconds := p_req.pkt.transmitSeconds,
+		originateFraction := p_req.pkt.transmitFraction,
+		receiveSeconds := v_seconds,
+		receiveFraction := c_sntp_zero_word,
+		transmitSeconds := v_seconds,
+		transmitFraction := c_sntp_zero_word
+	};
+}
+
+function f_send_reply(in RequestSeen p_req, in SNTP_Packet p_reply) runs on SNTP_MTC
+{
+	f_send_to(p_req.fromAddr, p_req.fromPort, bit2oct(encvalue(p_reply)));
+}
+
+function f_send_raw(in RequestSeen p_req, in octetstring p_msg) runs on SNTP_MTC
+{
+	f_send_to(p_req.fromAddr, p_req.fromPort, p_msg);
+}
+
+/* How far the clock that stamped a request is from a given time, in seconds. */
+function f_clock_distance(in RequestSeen p_req, in integer p_unix) return integer
+{
+	return f_abs(oct2int(p_req.pkt.transmitSeconds) - f_ntp_seconds(p_unix));
+}
+
+/* Answer the next request with p_unix and wait for the request after it, which
+ * has to carry p_unix for the reply to have been accepted.
+ *
+ * The request it returns is the one that came back, so a caller has something
+ * to answer without waiting again.
+ */
+function f_sync_to(in integer p_unix) runs on SNTP_MTC return RequestSeen
+{
+	var RequestSeen v_req := f_await_request();
+	var RequestSeen v_next;
+
+	f_send_reply(v_req, f_good_reply(v_req, p_unix));
+
+	v_next := f_await_request();
+	if (f_clock_distance(v_next, p_unix) > tsp_clock_tolerance) {
+		setverdict(fail, "the clock was not set from a reply that is "&
+			   "correct in every field, so the tests that follow "&
+			   "cannot tell an accepted reply from a rejected one");
+		stop;
+	}
+
+	return v_next;
+}
+
+/* The other half of the same idea: the clock must not have moved to a time
+ * that was offered in a reply the client should have thrown away.
+ */
+function f_expect_time_refused(in integer p_unix, in charstring p_why)
+runs on SNTP_MTC
+{
+	var RequestSeen v_next := f_await_request();
+
+	if (f_clock_distance(v_next, p_unix) <= tsp_clock_tolerance) {
+		setverdict(fail, "the clock was set from a reply that ", p_why);
+	} else {
+		setverdict(pass);
+	}
+}
+
+/* Every field of a request is fixed by RFC 4330 section 4, table 3, except the
+ * transmit timestamp, which is when the client sent it.
+ */
+function f_check_request_shape(in RequestSeen p_req) runs on SNTP_MTC
+{
+	if (p_req.pkt.li != c_sntp_li_none) {
+		setverdict(fail, "the leap indicator is ", p_req.pkt.li,
+			   " rather than 0");
+	}
+	if (p_req.pkt.vn < 1 or p_req.pkt.vn > 4) {
+		setverdict(fail, "the version is ", p_req.pkt.vn,
+			   ", which is outside 1 to 4");
+	}
+	if (p_req.pkt.mode != c_sntp_mode_client) {
+		setverdict(fail, "the mode is ", p_req.pkt.mode,
+			   " rather than 3, which is what a unicast request is");
+	}
+	if (p_req.pkt.stratum != 0) {
+		setverdict(fail, "the stratum is ", p_req.pkt.stratum,
+			   " rather than 0");
+	}
+	if (p_req.pkt.poll != 0) {
+		setverdict(fail, "the poll interval is ", p_req.pkt.poll,
+			   " rather than 0");
+	}
+	if (p_req.pkt.precision != '00'O) {
+		setverdict(fail, "the precision is ", p_req.pkt.precision,
+			   " rather than 0");
+	}
+	if (p_req.pkt.rootDelay != c_sntp_zero_word or
+	    p_req.pkt.rootDispersion != c_sntp_zero_word) {
+		setverdict(fail, "the root delay and dispersion belong to a "&
+			   "server and should be 0 in a request");
+	}
+	if (p_req.pkt.referenceId != c_sntp_zero_word or
+	    p_req.pkt.referenceSeconds != c_sntp_zero_word or
+	    p_req.pkt.referenceFraction != c_sntp_zero_word) {
+		setverdict(fail, "the reference identifier and timestamp "&
+			   "belong to a server and should be 0 in a request");
+	}
+	if (p_req.pkt.originateSeconds != c_sntp_zero_word or
+	    p_req.pkt.originateFraction != c_sntp_zero_word or
+	    p_req.pkt.receiveSeconds != c_sntp_zero_word or
+	    p_req.pkt.receiveFraction != c_sntp_zero_word) {
+		setverdict(fail, "the originate and receive timestamps are "&
+			   "filled in by the server and should be 0 in a request");
+	}
+	/* The transmit timestamp is what the reply is matched against, so a
+	 * request that leaves it at zero can be answered by anything.
+	 */
+	if (p_req.pkt.transmitSeconds == c_sntp_zero_word and
+	    p_req.pkt.transmitFraction == c_sntp_zero_word) {
+		setverdict(fail, "the transmit timestamp is 0, so nothing "&
+			   "identifies the reply that belongs to this request");
+	}
+}
+
+/* A request says what it is and leaves everything the server fills in alone.
+ * RFC 4330 section 4, table 3.
+ */
+testcase tc_request_is_well_formed() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+
+	f_open();
+	v_req := f_await_request();
+	f_check_request_shape(v_req);
+
+	setverdict(pass);
+	f_close();
+}
+
+/* The transmit timestamp is the only thing tying a reply to the request it
+ * answers, so a client that sent the same one twice could be given a stale
+ * reply and not know. RFC 4330 section 5, and RFC 8633 section 5.3 for why it
+ * is worth randomising rather than merely advancing.
+ */
+testcase tc_transmit_timestamp_varies() runs on SNTP_MTC
+{
+	var RequestsSeen v_seen;
+	var integer v_repeats := 0;
+
+	f_open();
+	v_seen := f_await_requests(tsp_request_sample);
+
+	for (var integer i := 1; i < lengthof(v_seen); i := i + 1) {
+		if (v_seen[i].pkt.transmitSeconds == v_seen[i - 1].pkt.transmitSeconds and
+		    v_seen[i].pkt.transmitFraction == v_seen[i - 1].pkt.transmitFraction) {
+			v_repeats := v_repeats + 1;
+		}
+	}
+
+	if (v_repeats > 0) {
+		setverdict(fail, v_repeats, " of ", lengthof(v_seen) - 1,
+			   " requests repeat the transmit timestamp of the one "&
+			   "before, so a reply to one would answer the other");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* A request that goes unanswered has to be repeated, and sooner than the
+ * client would have asked again of its own accord. RFC 4330 section 5 asks for
+ * a backoff rather than a fixed rate, so this only counts what arrives.
+ */
+testcase tc_unanswered_request_is_repeated() runs on SNTP_MTC
+{
+	var RequestSeen v_first;
+	var integer v_count;
+
+	f_open();
+
+	/* Wait for the first one before starting the clock, so that the window
+	 * covers a query rather than the tail of the interval before it.
+	 */
+	v_first := f_await_request();
+	v_count := f_count_requests(tsp_backoff_window);
+
+	if (v_count < tsp_backoff_minimum) {
+		setverdict(fail, "only ", v_count, " further requests in ",
+			   tsp_backoff_window, "s after the one from port ",
+			   v_first.fromPort, ", so the client is waiting out "&
+			   "its whole interval rather than retransmitting");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* The point of the whole thing: a reply that is right in every field is taken,
+ * and the time it carries becomes the client's time.
+ */
+testcase tc_reply_sets_the_clock() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+	var RequestSeen v_next;
+
+	f_open();
+
+	v_req := f_await_request();
+	f_send_reply(v_req, f_good_reply(v_req, tsp_time_accepted));
+
+	v_next := f_await_request();
+	if (f_clock_distance(v_next, tsp_time_accepted) > tsp_clock_tolerance) {
+		setverdict(fail, "the clock did not follow a reply that is "&
+			   "correct in every field: the next request is stamped ",
+			   oct2int(v_next.pkt.transmitSeconds), " rather than ",
+			   f_ntp_seconds(tsp_time_accepted));
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* The originate timestamp is the client's own transmit timestamp handed back.
+ * A reply that carries anything else is answering some other request, or no
+ * request at all, and taking the time from it would let an off path attacker
+ * set the clock without ever seeing what was asked. RFC 4330 section 5,
+ * sanity check 3.
+ */
+testcase tc_originate_timestamp_must_be_echoed() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+	var SNTP_Packet v_reply;
+
+	f_open();
+	v_req := f_sync_to(tsp_time_accepted);
+
+	v_reply := f_good_reply(v_req, tsp_time_originate);
+	/* One second out is enough: it is a different request. */
+	v_reply.originateSeconds :=
+		int2oct(oct2int(v_req.pkt.transmitSeconds) + 1, 4);
+
+	f_send_reply(v_req, v_reply);
+	f_expect_time_refused(tsp_time_originate,
+			      "does not carry back the transmit timestamp of "&
+			      "the request it claims to answer");
+
+	f_close();
+}
+
+/* A reply to a unicast request is mode 4. Mode 3 is another client asking, and
+ * whatever it is, it is not an answer. RFC 4330 section 4, table 3.
+ */
+testcase tc_reply_must_be_mode_server() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+	var SNTP_Packet v_reply;
+
+	f_open();
+	v_req := f_sync_to(tsp_time_accepted);
+
+	v_reply := f_good_reply(v_req, tsp_time_mode);
+	v_reply.mode := c_sntp_mode_client;
+
+	f_send_reply(v_req, v_reply);
+	f_expect_time_refused(tsp_time_mode, "is mode 3 rather than mode 4");
+
+	f_close();
+}
+
+/* Stratum 0 is not a stratum. It says the reply is a kiss-o'-death carrying a
+ * four character reason where the reference identifier goes, and no time at
+ * all. RFC 4330 section 8.
+ *
+ * That section also asks a client with no other server to back off rather than
+ * keep asking at the same rate. Nothing is asserted about that here: the
+ * backoff belongs to whatever drives the client rather than to the client
+ * itself.
+ */
+testcase tc_kiss_of_death_is_not_a_time_source() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+	var SNTP_Packet v_reply;
+
+	f_open();
+	v_req := f_sync_to(tsp_time_accepted);
+
+	v_reply := f_good_reply(v_req, tsp_time_kod);
+	v_reply.stratum := c_sntp_stratum_kod;
+	/* "RATE": asking too often. */
+	v_reply.referenceId := '52415445'O;
+
+	f_send_reply(v_req, v_reply);
+	f_expect_time_refused(tsp_time_kod,
+			      "is a kiss-o'-death packet rather than a time");
+
+	f_close();
+}
+
+/* A transmit timestamp of zero says the server has never had the time to
+ * give. RFC 4330 section 4, table 3, requires it to be nonzero in a reply.
+ */
+testcase tc_zero_transmit_timestamp_is_rejected() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+	var SNTP_Packet v_reply;
+	var RequestSeen v_next;
+
+	f_open();
+	v_req := f_sync_to(tsp_time_accepted);
+
+	v_reply := f_good_reply(v_req, tsp_time_accepted);
+	v_reply.transmitSeconds := c_sntp_zero_word;
+	v_reply.transmitFraction := c_sntp_zero_word;
+
+	f_send_reply(v_req, v_reply);
+
+	/* There is no offered time to look for here, so this one checks that
+	 * the clock stayed where the synchronisation left it. A client that
+	 * took the timestamp would have wound it back to 1900.
+	 */
+	v_next := f_await_request();
+	if (f_clock_distance(v_next, tsp_time_accepted) > tsp_clock_tolerance) {
+		setverdict(fail, "the clock moved after a reply whose transmit "&
+			   "timestamp is 0");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* The message is a fixed length. Something shorter is not a reply that lost a
+ * few fields, it is not a reply, and reading the fields that did arrive would
+ * mean reading whatever the buffer held before.
+ */
+testcase tc_truncated_reply_is_rejected() runs on SNTP_MTC
+{
+	var RequestSeen v_req;
+	var octetstring v_msg;
+
+	f_open();
+	v_req := f_sync_to(tsp_time_accepted);
+
+	v_msg := bit2oct(encvalue(f_good_reply(v_req, tsp_time_truncated)));
+	/* Everything up to the transmit timestamp, which is where the time it
+	 * would be taken from lives.
+	 */
+	v_msg := substr(v_msg, 0, c_sntp_packet_length - 8);
+
+	f_send_raw(v_req, v_msg);
+	f_expect_time_refused(tsp_time_truncated,
+			      "is shorter than a message can be");
+
+	f_close();
+}
+
+control {
+	execute(tc_request_is_well_formed());
+	execute(tc_transmit_timestamp_varies());
+	execute(tc_unanswered_request_is_repeated());
+	execute(tc_reply_sets_the_clock());
+	execute(tc_originate_timestamp_must_be_echoed());
+	execute(tc_reply_must_be_mode_server());
+	execute(tc_kiss_of_death_is_not_a_time_source());
+	execute(tc_zero_transmit_timestamp_is_rejected());
+	execute(tc_truncated_reply_is_rejected());
+}
+
+}

--- a/ttcn3/suites/sntp/SNTP_Types.ttcn
+++ b/ttcn3/suites/sntp/SNTP_Types.ttcn
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The SNTP message, RFC 4330 section 4.
+ *
+ * The Titan project publishes no protocol module for this one. The message is
+ * a fixed 48 octets with no options and no variable parts, so writing it out
+ * is less work than depending on something that would have to be found first,
+ * and it follows the same reasoning as ARP_Types in the shared layer.
+ *
+ * The authenticator that may follow the 48 octets is not described. Zephyr
+ * neither sends nor accepts one: sntp_recv_response() requires a datagram of
+ * exactly the header length, so anything carrying an authenticator would be
+ * discarded before it was looked at.
+ *
+ * The four timestamps are kept as octets rather than integers so that the
+ * encoding is not at the mercy of a byte order attribute. A timestamp is a
+ * 64-bit fixed point number, seconds in the first word and a binary fraction
+ * of a second in the second; the tests here only ever reason about the
+ * seconds, which oct2int reads in network order by definition.
+ */
+module SNTP_Types {
+
+import from General_Types all;
+
+type record SNTP_Packet {
+	INT2b	li,
+	INT3b	vn,
+	INT3b	mode,
+	LIN1	stratum,
+	LIN1	poll,
+	OCT1	precision,
+	OCT4	rootDelay,
+	OCT4	rootDispersion,
+	OCT4	referenceId,
+	OCT4	referenceSeconds,
+	OCT4	referenceFraction,
+	OCT4	originateSeconds,
+	OCT4	originateFraction,
+	OCT4	receiveSeconds,
+	OCT4	receiveFraction,
+	OCT4	transmitSeconds,
+	OCT4	transmitFraction
+} with { variant "FIELDORDER(msb)" }
+
+/* Length of the message above, which is also the only length Zephyr accepts. */
+const integer c_sntp_packet_length := 48;
+
+/* Leap indicator. A client sends 0; 3 in a reply says the server's own clock
+ * is not synchronised. RFC 4330 section 4.
+ */
+const INT2b c_sntp_li_none := 0;
+const INT2b c_sntp_li_unsynchronised := 3;
+
+/* Mode. A unicast request is 3 and the reply to it is 4. */
+const INT3b c_sntp_mode_client := 3;
+const INT3b c_sntp_mode_server := 4;
+
+/* Stratum. 0 in a reply is not a stratum at all but a kiss-o'-death packet,
+ * which carries a four character reason in the reference identifier instead
+ * of a time. RFC 4330 section 8.
+ */
+const LIN1 c_sntp_stratum_kod := 0;
+const LIN1 c_sntp_stratum_primary := 1;
+
+/* Seconds between the NTP epoch of 1 January 1900 and the POSIX epoch of
+ * 1 January 1970. A timestamp on the wire counts from the former.
+ */
+const integer c_ntp_epoch_offset := 2208988800;
+
+const OCT4 c_sntp_zero_word := '00000000'O;
+
+} with { encode "RAW" }

--- a/ttcn3/suites/sntp/sntp.cfg
+++ b/ttcn3/suites/sntp/sntp.cfg
@@ -1,0 +1,35 @@
+# Runtime configuration for the SNTP client conformance suite.
+#
+# The addresses below are the defaults that tests/net/conformance/sntp is built
+# with, paired with the addresses net-setup.sh puts on zeth. Override them here
+# to run against a different link.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_sut_ipv6 := "2001:db8::1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_tester_ipv6 := "2001:db8::2"
+# The system under test gives a query two seconds before it gives up and waits
+# half a second before the next one, so a request is never far away.
+Zephyr_SUT.tsp_response_timeout := 10.0
+Zephyr_SUT.tsp_silence_timeout := 2.0
+
+# Has to match SERVER_PORT in the system under test.
+SNTP_Suite.tsp_sntp_port := 12123
+SNTP_Suite.tsp_request_sample := 4
+SNTP_Suite.tsp_clock_tolerance := 60
+
+# Long enough to cover a query the client has given up on, short enough that
+# the queries after it are not counted with its retransmissions.
+SNTP_Suite.tsp_backoff_window := 2.5
+SNTP_Suite.tsp_backoff_minimum := 3
+
+[LOGGING]
+LogFile := "sntp-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+SNTP_Suite.control

--- a/ttcn3/suites/sntp/sources.txt
+++ b/ttcn3/suites/sntp/sources.txt
@@ -1,0 +1,5 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+#
+# None. The message is described by SNTP_Types.ttcn in this directory, because
+# the Titan project publishes no protocol module for SNTP.

--- a/ttcn3/suites/tcp/TCP_Suite.ttcn
+++ b/ttcn3/suites/tcp/TCP_Suite.ttcn
@@ -1,0 +1,710 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Conformance tests for Zephyr's TCP, RFC 9293.
+ *
+ * The tester builds every header itself, down to the ethernet one, and reads
+ * frames off the link. Nothing is compiled into Zephyr for these tests and
+ * there is no control channel: the system under test is an ordinary
+ * application, a server that echoes and a client that connects out, so the TCP
+ * being exercised is the one that ships rather than one built for testing.
+ *
+ * Working this far down means answering address resolution as well. On a link
+ * whose Linux side has no address nothing else will, and a system under test
+ * that cannot resolve the tester cannot reply to it, so every wait for a
+ * segment answers any request that arrives while it waits.
+ *
+ * The scenarios come from the suite Intel published for the TCP rewrite, which
+ * covered handshake, data, sequence wrap, window, retransmission and malformed
+ * segments. That suite asserted Zephyr's internal state through a test protocol
+ * channel; these tests assert what is on the wire instead, so they say nothing
+ * about how the stack is written.
+ *
+ * The system under test is tests/net/conformance/tcp in the Zephyr tree.
+ */
+module TCP_Suite {
+
+import from General_Types all;
+import from ARP_Types all;
+import from IP_Types all;
+import from TCP_Types all;
+import from Ethernet_Port all;
+import from TCCConversion_Functions all;
+import from Zephyr_SUT all;
+
+modulepar charstring tsp_tester_mac := "020000000002";
+
+/* The port the system under test echoes on, the one it connects out to, and
+ * one nothing listens on.
+ */
+modulepar integer tsp_echo_port := 4242;
+modulepar integer tsp_connect_port := 4243;
+modulepar integer tsp_closed_port := 4299;
+
+const OCT2 c_ethertype_ipv4 := '0800'O;
+
+type component TCP_MTC {
+	port Ethernet_PT pt;
+	timer t_guard;
+
+	/* What the tester has learned about the other end of the link. */
+	var OCT6 v_sut_mac := '000000000000'O;
+
+	/* Where the connection under test has got to. */
+	var integer v_local_port := 0;
+	var integer v_snd := 0;		/* what the tester will send next */
+	var integer v_rcv := 0;		/* what the tester expects next */
+	var boolean v_established := false;
+}
+
+/*
+ * Addresses
+ */
+
+function f_mac(in charstring p_mac) return OCT6
+{
+	return str2oct(p_mac);
+}
+
+function f_ipv4(in charstring p_addr) return OCT4
+{
+	return f_convertIPAddrToBinary(p_addr);
+}
+
+/*
+ * Building and sending
+ */
+
+/* Wrap a TCP segment in IP and ethernet and put it on the link. The encoders
+ * fill in the lengths and both checksums, which is the main reason for using
+ * the protocol modules rather than writing the headers out here.
+ */
+function f_send_tcp(in PDU_TCP p_tcp, in OCT6 p_eth_dst,
+		    in boolean p_auto_offset := true) runs on TCP_MTC
+{
+	var octetstring v_src := f_ipv4(tsp_tester_ipv4);
+	var octetstring v_dst := f_ipv4(tsp_sut_ipv4);
+	var octetstring v_segment := f_enc_PDU_TCP(v_src, v_dst, p_tcp,
+						   p_auto_offset, true);
+	var IPv4_packet v_ip;
+
+	v_ip := {
+		header := {
+			ver := 4,
+			hlen := 5,
+			tos := 0,
+			tlen := 20 + lengthof(v_segment),
+			id := 0,
+			res := '0'B,
+			dfrag := '1'B,
+			mfrag := '0'B,
+			foffset := 0,
+			ttl := 64,
+			proto := 6,
+			cksum := 0,
+			srcaddr := v_src,
+			dstaddr := v_dst
+		},
+		ext_headers := omit,
+		payload := v_segment
+	};
+
+	pt.send(Ethernet_Frame:{
+		destination := p_eth_dst,
+		source := f_mac(tsp_tester_mac),
+		etherType := c_ethertype_ipv4,
+		payload := f_ipv4_with_checksum(v_ip)
+	});
+}
+
+/* The encoder fills in the total length but not the header checksum, and a
+ * header whose checksum is wrong is dropped before anything looks at what is
+ * inside it. Work it out over the encoded header and put it in place, rather
+ * than through the record field, so that no byte order question arises.
+ */
+function f_ipv4_with_checksum(in IPv4_packet p_ip) return octetstring
+{
+	var octetstring v_bytes := f_IPv4_enc(p_ip);
+	var OCT2 v_sum := f_IPv4_checksum(substr(v_bytes, 0, 20));
+
+	return replace(v_bytes, 10, 2, v_sum);
+}
+
+template PDU_TCP t_segment(in integer p_dst_port, in integer p_seq,
+			   in integer p_ack, in TCP_Control_bits p_flags,
+			   in integer p_window := 4096) := {
+	source_port := 0,
+	dest_port := p_dst_port,
+	sequence_number := p_seq,
+	acknowledgment_number := p_ack,
+	data_offset := 5,
+	reserved := '000000'B,
+	control_bits := p_flags,
+	window := p_window,
+	checksum := '0000'O,
+	urgent_pointer := 0,
+	options := omit,
+	data := omit
+}
+
+const TCP_Control_bits c_syn := { urg := '0'B, ack := '0'B, psh := '0'B,
+				  rst := '0'B, syn := '1'B, fin := '0'B };
+const TCP_Control_bits c_syn_ack := { urg := '0'B, ack := '1'B, psh := '0'B,
+				      rst := '0'B, syn := '1'B, fin := '0'B };
+const TCP_Control_bits c_ack := { urg := '0'B, ack := '1'B, psh := '0'B,
+				  rst := '0'B, syn := '0'B, fin := '0'B };
+const TCP_Control_bits c_psh_ack := { urg := '0'B, ack := '1'B, psh := '1'B,
+				      rst := '0'B, syn := '0'B, fin := '0'B };
+const TCP_Control_bits c_fin_ack := { urg := '0'B, ack := '1'B, psh := '0'B,
+				      rst := '0'B, syn := '0'B, fin := '1'B };
+const TCP_Control_bits c_rst := { urg := '0'B, ack := '0'B, psh := '0'B,
+				  rst := '1'B, syn := '0'B, fin := '0'B };
+
+function f_send(in integer p_dst_port, in TCP_Control_bits p_flags,
+		in octetstring p_data := ''O) runs on TCP_MTC
+{
+	var PDU_TCP v_tcp := valueof(t_segment(p_dst_port, v_snd, v_rcv, p_flags));
+
+	v_tcp.source_port := v_local_port;
+
+	if (lengthof(p_data) > 0) {
+		v_tcp.data := p_data;
+	}
+
+	f_send_tcp(v_tcp, v_sut_mac);
+
+	/* A synchronise or a finish takes a sequence number of its own. */
+	v_snd := (v_snd + lengthof(p_data)) mod 4294967296;
+
+	if (p_flags.syn == '1'B) {
+		v_snd := (v_snd + 1) mod 4294967296;
+	}
+	if (p_flags.fin == '1'B) {
+		v_snd := (v_snd + 1) mod 4294967296;
+	}
+}
+
+/*
+ * Address resolution, which this suite serves rather than tests
+ */
+
+function f_answer_arp(in Ethernet_Frame p_frame) runs on TCP_MTC return boolean
+{
+	var bitstring v_bits := oct2bit(p_frame.payload);
+	var ARP_Packet v_arp;
+	var ARP_Packet v_reply;
+
+	if (p_frame.etherType != c_ethertype_arp) {
+		return false;
+	}
+
+	if (decvalue(v_bits, v_arp) != 0) {
+		return true;
+	}
+
+	/* Remember where the other end is, whatever it was asking. */
+	if (v_arp.senderProtoAddr == f_ipv4(tsp_sut_ipv4)) {
+		v_sut_mac := v_arp.senderHwAddr;
+	}
+
+	if (v_arp.operation != c_arp_request or
+	    v_arp.targetProtoAddr != f_ipv4(tsp_tester_ipv4)) {
+		return true;
+	}
+
+	v_reply := {
+		hwType := c_arp_hw_ethernet,
+		protoType := c_arp_proto_ipv4,
+		hwLen := 6,
+		protoLen := 4,
+		operation := c_arp_reply,
+		senderHwAddr := f_mac(tsp_tester_mac),
+		senderProtoAddr := f_ipv4(tsp_tester_ipv4),
+		targetHwAddr := v_arp.senderHwAddr,
+		targetProtoAddr := v_arp.senderProtoAddr
+	};
+
+	pt.send(Ethernet_Frame:{
+		destination := v_arp.senderHwAddr,
+		source := f_mac(tsp_tester_mac),
+		etherType := c_ethertype_arp,
+		payload := bit2oct(encvalue(v_reply))
+	});
+
+	return true;
+}
+
+/*
+ * Waiting
+ */
+
+/* Wait for a TCP segment from the system under test, answering address
+ * resolution and ignoring anything else that arrives meanwhile. Fails the test
+ * case and stops it if nothing comes, so callers can use the result directly.
+ */
+function f_await_tcp(in float p_timeout := -1.0) runs on TCP_MTC return PDU_TCP
+{
+	var Ethernet_Frame v_frame;
+	var IPv4_packet v_ip;
+	var float v_timeout := p_timeout;
+
+	if (v_timeout < 0.0) {
+		v_timeout := tsp_response_timeout;
+	}
+
+	t_guard.start(v_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		if (f_answer_arp(v_frame)) {
+			repeat;
+		}
+
+		if (v_frame.etherType != c_ethertype_ipv4) {
+			repeat;
+		}
+
+		v_ip := f_IPv4_dec(v_frame.payload);
+
+		if (v_ip.header.proto != 6 or not ispresent(v_ip.payload)) {
+			repeat;
+		}
+
+		if (v_ip.header.srcaddr != f_ipv4(tsp_sut_ipv4)) {
+			repeat;
+		}
+
+		t_guard.stop;
+		v_sut_mac := v_frame.source;
+
+		return f_dec_PDU_TCP(v_ip.payload);
+	}
+	[] t_guard.timeout {
+		setverdict(fail, "no segment within ", v_timeout, "s");
+		stop;
+	}
+	}
+
+	/* Unreachable, but the compiler wants a return on every path. */
+	return f_dec_PDU_TCP(''O);
+}
+
+/* Wait for a segment belonging to the connection under test. Anything else on
+ * the link, including the connection attempts the system under test makes of
+ * its own accord, is skipped.
+ */
+function f_await_segment(in float p_timeout := -1.0) runs on TCP_MTC return PDU_TCP
+{
+	for (var integer i := 0; i < 20; i := i + 1) {
+		var PDU_TCP v_tcp := f_await_tcp(p_timeout);
+
+		if (v_tcp.dest_port == v_local_port) {
+			return v_tcp;
+		}
+	}
+
+	setverdict(fail, "nothing for this connection among the segments seen");
+	stop;
+}
+
+/* Require that the connection under test hears nothing more. */
+function f_expect_no_segment(in charstring p_why) runs on TCP_MTC
+{
+	var Ethernet_Frame v_frame;
+	var IPv4_packet v_ip;
+	var PDU_TCP v_tcp;
+
+	t_guard.start(tsp_silence_timeout);
+	alt {
+	[] pt.receive(Ethernet_Frame:?) -> value v_frame {
+		if (f_answer_arp(v_frame) or v_frame.etherType != c_ethertype_ipv4) {
+			repeat;
+		}
+
+		v_ip := f_IPv4_dec(v_frame.payload);
+		if (v_ip.header.proto != 6 or not ispresent(v_ip.payload)) {
+			repeat;
+		}
+
+		v_tcp := f_dec_PDU_TCP(v_ip.payload);
+		if (v_tcp.dest_port != v_local_port) {
+			repeat;
+		}
+
+		t_guard.stop;
+		setverdict(fail, "it answered when it should not have: ", p_why);
+	}
+	[] t_guard.timeout {
+		setverdict(pass);
+	}
+	}
+}
+
+/*
+ * Opening and closing
+ */
+
+function f_open(in integer p_local_port) runs on TCP_MTC
+{
+	map(mtc:pt, system:pt);
+
+	v_local_port := p_local_port;
+	v_snd := 0;
+	v_rcv := 0;
+	v_established := false;
+	v_sut_mac := c_mac_broadcast;
+}
+
+/* Tear any connection down before leaving, so that the next test case starts
+ * against a system under test that is listening again. The application accepts
+ * one connection at a time, so one left open would leave every test after it
+ * waiting for an answer that cannot come.
+ */
+/* Give the far side a moment. The stack acts on a reset at once, but the
+ * application behind it has to notice, close its side and come back round to
+ * accepting, and a connection opened in the same breath as the one before it
+ * was closed can arrive before that has happened.
+ */
+function f_settle() runs on TCP_MTC
+{
+	t_guard.start(1.0);
+	t_guard.timeout;
+}
+
+function f_close() runs on TCP_MTC
+{
+	if (v_established) {
+		f_send(tsp_echo_port, c_rst);
+		v_established := false;
+	}
+
+	unmap(mtc:pt, system:pt);
+}
+
+/* Learn where the other end is, so that segments can be addressed to it
+ * rather than broadcast. The system under test connects out on its own, so
+ * something from it arrives without having to be asked for.
+ */
+function f_learn_peer() runs on TCP_MTC
+{
+	var PDU_TCP v_ignored;
+
+	if (v_sut_mac != c_mac_broadcast) {
+		return;
+	}
+
+	v_ignored := f_await_tcp();
+}
+
+/* The three way handshake, from the tester's side. Leaves the connection open
+ * with the sequence numbers tracked.
+ */
+function f_handshake(in integer p_seq := 1000) runs on TCP_MTC return PDU_TCP
+{
+	var PDU_TCP v_synack;
+
+	f_learn_peer();
+
+	v_snd := p_seq;
+	v_rcv := 0;
+
+	f_send(tsp_echo_port, c_syn);
+
+	v_synack := f_await_segment();
+
+	if (v_synack.control_bits.syn != '1'B or v_synack.control_bits.ack != '1'B) {
+		setverdict(fail, "the answer to a synchronise is not a "&
+			   "synchronise and acknowledge");
+		f_close();
+		stop;
+	}
+
+	if (v_synack.acknowledgment_number != v_snd) {
+		setverdict(fail, "it acknowledged ", v_synack.acknowledgment_number,
+			   " rather than ", v_snd);
+	}
+
+	v_rcv := (v_synack.sequence_number + 1) mod 4294967296;
+	f_send(tsp_echo_port, c_ack);
+	v_established := true;
+
+	return v_synack;
+}
+
+/*
+ * Test cases
+ */
+
+/* A synchronise has to be answered with one that acknowledges it, and the
+ * connection has to come up. RFC 9293 3.5.
+ */
+testcase tc_handshake() runs on TCP_MTC
+{
+	var PDU_TCP v_synack;
+
+	f_open(40001);
+	v_synack := f_handshake();
+
+	setverdict(pass);
+	f_close();
+}
+
+/* The initial sequence number has to be hard to guess, otherwise anything that
+ * can reach the link can inject into a connection it cannot see. RFC 9293 3.4.
+ */
+testcase tc_initial_sequence_number_varies() runs on TCP_MTC
+{
+	var PDU_TCP v_first;
+	var PDU_TCP v_second;
+
+	f_open(40002);
+	v_first := f_handshake();
+
+	/* A second connection from a different port, so it is a new one rather
+	 * than a repeat of the first. The first is reset first, because the
+	 * application accepts one at a time.
+	 */
+	f_send(tsp_echo_port, c_rst);
+	v_established := false;
+	f_settle();
+	v_local_port := 40003;
+	v_second := f_handshake(2000);
+
+	if (v_first.sequence_number == v_second.sequence_number) {
+		setverdict(fail, "both connections started from the same "&
+			   "sequence number, so it is not random");
+	} else if (v_second.sequence_number == v_first.sequence_number + 1) {
+		setverdict(fail, "the sequence number counts up, so it is "&
+			   "predictable");
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* Data has to be acknowledged and, since the far side echoes, come back. What
+ * matters here is the accounting: the acknowledgement has to cover exactly
+ * what was sent.
+ */
+testcase tc_data_is_acknowledged_and_echoed() runs on TCP_MTC
+{
+	var octetstring v_data := '414243'O;
+	var PDU_TCP v_segment;
+	var PDU_TCP v_synack;
+	var integer v_expected;
+
+	f_open(40004);
+	v_synack := f_handshake();
+
+	v_expected := (v_snd + lengthof(v_data)) mod 4294967296;
+	f_send(tsp_echo_port, c_psh_ack, v_data);
+
+	/* The echo may come with the acknowledgement or after it. */
+	for (var integer i := 0; i < 4; i := i + 1) {
+		v_segment := f_await_segment();
+
+		if (v_segment.acknowledgment_number != v_expected) {
+			setverdict(fail, "it acknowledged ",
+				   v_segment.acknowledgment_number,
+				   " rather than ", v_expected);
+		}
+
+		if (ispresent(v_segment.data) and lengthof(v_segment.data) > 0) {
+			if (v_segment.data != v_data) {
+				setverdict(fail, "it echoed something else");
+			}
+
+			setverdict(pass);
+			f_close();
+			stop;
+		}
+	}
+
+	setverdict(fail, "the data was never echoed back");
+	f_close();
+}
+
+/* A synchronise to a port nothing listens on has to be refused, and refused
+ * with a reset rather than by silence: a client that hears nothing waits for
+ * its timeout instead of failing at once. RFC 9293 3.10.7.2.
+ */
+testcase tc_closed_port_is_reset() runs on TCP_MTC
+{
+	var PDU_TCP v_answer;
+
+	f_open(40005);
+	f_learn_peer();
+
+	v_snd := 3000;
+	v_rcv := 0;
+	f_send(tsp_closed_port, c_syn);
+
+	v_answer := f_await_segment();
+
+	if (v_answer.control_bits.rst != '1'B) {
+		setverdict(fail, "a synchronise to a port nothing listens on "&
+			   "was answered with something other than a reset");
+	} else if (v_answer.acknowledgment_number != v_snd) {
+		setverdict(fail, "the reset acknowledges ",
+			   v_answer.acknowledgment_number, " rather than ", v_snd);
+	} else {
+		setverdict(pass);
+	}
+
+	f_close();
+}
+
+/* A finish has to be acknowledged, and the far side has to send one of its own
+ * once it has nothing left to say. RFC 9293 3.5.
+ */
+testcase tc_close_is_completed() runs on TCP_MTC
+{
+	var PDU_TCP v_segment;
+	var PDU_TCP v_synack;
+	var boolean v_acked := false;
+	var boolean v_finished := false;
+
+	f_open(40006);
+	v_synack := f_handshake();
+
+	f_send(tsp_echo_port, c_fin_ack);
+
+	for (var integer i := 0; i < 4 and not (v_acked and v_finished);
+	     i := i + 1) {
+		v_segment := f_await_segment();
+
+		if (v_segment.acknowledgment_number == v_snd) {
+			v_acked := true;
+		}
+
+		if (v_segment.control_bits.fin == '1'B) {
+			v_finished := true;
+		}
+	}
+
+	if (not v_acked) {
+		setverdict(fail, "the finish was never acknowledged");
+	} else if (not v_finished) {
+		setverdict(fail, "it never finished its own side");
+	} else {
+		setverdict(pass);
+	}
+
+	v_established := false;
+	f_close();
+}
+
+/* A segment claiming a header shorter than a header has to be dropped rather
+ * than parsed. Acting on one means reading fields out of the payload.
+ */
+testcase tc_undersized_data_offset_is_dropped() runs on TCP_MTC
+{
+	var PDU_TCP v_tcp;
+
+	f_open(40007);
+	f_learn_peer();
+
+	v_snd := 4000;
+	v_rcv := 0;
+
+	v_tcp := valueof(t_segment(tsp_echo_port, v_snd, 0, c_syn));
+	v_tcp.source_port := v_local_port;
+	/* Four words, one short of the smallest header there is. The encoder
+	 * is told not to work the offset out for itself.
+	 */
+	v_tcp.data_offset := 4;
+
+	f_send_tcp(v_tcp, v_sut_mac, false);
+
+	f_expect_no_segment("the segment claimed a header shorter than a header");
+	f_close();
+}
+
+/* Sequence numbers wrap, and a connection whose numbers wrap during it has to
+ * keep working. Starting just below the wrap makes it happen at once rather
+ * than after four gigabytes.
+ */
+testcase tc_sequence_number_wraps() runs on TCP_MTC
+{
+	var octetstring v_data := '5758595A'O;
+	var PDU_TCP v_segment;
+	var PDU_TCP v_synack;
+	var integer v_expected;
+
+	f_open(40008);
+	v_synack := f_handshake(4294967290);
+
+	v_expected := (v_snd + lengthof(v_data)) mod 4294967296;
+	f_send(tsp_echo_port, c_psh_ack, v_data);
+
+	for (var integer i := 0; i < 4; i := i + 1) {
+		v_segment := f_await_segment();
+
+		if (v_segment.acknowledgment_number == v_expected) {
+			setverdict(pass);
+			f_close();
+			stop;
+		}
+	}
+
+	setverdict(fail, "the acknowledgement never covered the data sent "&
+		   "across the wrap");
+	f_close();
+}
+
+/* When the system under test is the one connecting, its synchronise has to say
+ * who it is and what it will accept.
+ */
+testcase tc_outbound_connect_is_well_formed() runs on TCP_MTC
+{
+	var PDU_TCP v_syn;
+
+	f_open(tsp_connect_port);
+
+	for (var integer i := 0; i < 20; i := i + 1) {
+		var PDU_TCP v_tcp := f_await_tcp();
+
+		if (v_tcp.dest_port == tsp_connect_port and
+		    v_tcp.control_bits.syn == '1'B) {
+			v_syn := v_tcp;
+
+			if (v_syn.control_bits.ack != '0'B) {
+				setverdict(fail, "the opening synchronise "&
+					   "acknowledges something");
+			}
+			if (v_syn.data_offset < 5) {
+				setverdict(fail, "the header is shorter than a header");
+			}
+			if (v_syn.window == 0) {
+				setverdict(fail, "it opened a connection it will "&
+					   "accept nothing on");
+			}
+			if (v_syn.source_port == 0) {
+				setverdict(fail, "it connected from port zero");
+			}
+
+			setverdict(pass);
+			f_close();
+			stop;
+		}
+	}
+
+	setverdict(fail, "it never tried to connect");
+	f_close();
+}
+
+control {
+	execute(tc_outbound_connect_is_well_formed());
+	execute(tc_handshake());
+	execute(tc_initial_sequence_number_varies());
+	execute(tc_data_is_acknowledged_and_echoed());
+	execute(tc_closed_port_is_reset());
+	execute(tc_close_is_completed());
+	execute(tc_undersized_data_offset_is_dropped());
+	execute(tc_sequence_number_wraps());
+}
+
+}

--- a/ttcn3/suites/tcp/build.conf
+++ b/ttcn3/suites/tcp/build.conf
@@ -1,0 +1,7 @@
+# The tester builds its own ethernet, IP and TCP headers, which needs a packet
+# socket, which needs privilege an ordinary user does not have.
+PRIVILEGED=yes
+
+# It works below the IP layer, so it uses the interface that has no address
+# on the Linux side rather than the one the socket suites share.
+L2=yes

--- a/ttcn3/suites/tcp/sources.txt
+++ b/ttcn3/suites/tcp/sources.txt
@@ -1,0 +1,8 @@
+# Module sources this suite needs on top of common/sources.txt,
+# relative to ../../modules.
+
+titan.ProtocolModules.IP/src/IP_Types.ttcn
+titan.ProtocolModules.IP/src/IP_EncDec.cc
+
+titan.ProtocolModules.TCP/src/TCP_Types.ttcn
+titan.ProtocolModules.TCP/src/TCP_EncDec.cc

--- a/ttcn3/suites/tcp/tcp.cfg
+++ b/ttcn3/suites/tcp/tcp.cfg
@@ -1,0 +1,36 @@
+# Runtime configuration for the TCP conformance suite.
+#
+# The tester builds every header itself, down to the ethernet one, so it works
+# on the interface net-tools/zeth-l2.conf describes: no address on the Linux
+# side, so that nothing but this suite answers on the link.
+
+[MODULE_PARAMETERS]
+Zephyr_SUT.tsp_sut_ipv4 := "192.0.2.1"
+Zephyr_SUT.tsp_tester_ipv4 := "192.0.2.2"
+Zephyr_SUT.tsp_response_timeout := 10.0
+Zephyr_SUT.tsp_silence_timeout := 4.0
+
+# Twelve hexadecimal digits, no separators. Has to agree with source_address
+# below, which is what the test port puts in the frames it sends.
+TCP_Suite.tsp_tester_mac := "020000000002"
+TCP_Suite.tsp_echo_port := 4242
+TCP_Suite.tsp_connect_port := 4243
+TCP_Suite.tsp_closed_port := 4299
+
+[TESTPORT_PARAMETERS]
+# The port opens the interface when the port is mapped, so it reads all of
+# this for itself before any test code runs. There is no type filter: this
+# suite has to see address resolution as well as IP, because on this link
+# nothing else will answer it.
+system.pt.interface := "zethL2"
+system.pt.source_address := "020000000002"
+
+[LOGGING]
+LogFile := "tcp-%e.%s"
+FileMask := LOG_ALL
+ConsoleMask := TTCN_ERROR | TTCN_WARNING | TTCN_TESTCASE | TTCN_STATISTICS | USER
+LogSourceInfo := Yes
+TimeStampFormat := Time
+
+[EXECUTE]
+TCP_Suite.control

--- a/zeth-l2.conf
+++ b/zeth-l2.conf
@@ -1,0 +1,24 @@
+# Configuration file for an interface used to test at the ethernet layer.
+#
+# The interface deliberately gets no IP address. A test that checks how Zephyr
+# answers ARP, ICMP or neighbour discovery has to be the only thing on the link
+# that answers, and Linux answers for any address it holds on any interface
+# unless it is told not to. With no address here, and arp_ignore set to refuse
+# every local address, nothing on this side replies but the tester.
+#
+# The tester speaks raw frames on this interface, so it needs no address of its
+# own: the addresses it uses live only inside the frames it builds.
+
+INTERFACE="$1"
+
+HWADDR="00:00:5e:00:53:fe"
+
+ip link set dev $INTERFACE address $HWADDR
+ip link set dev $INTERFACE up
+
+# Do not answer ARP for any local address on this interface.
+sysctl -q -w net.ipv4.conf.$INTERFACE.arp_ignore=8
+# Do not answer ARP with an address this interface does not hold.
+sysctl -q -w net.ipv4.conf.$INTERFACE.arp_announce=2
+# No IPv6 either, so no neighbour advertisements and no router solicitations.
+sysctl -q -w net.ipv6.conf.$INTERFACE.disable_ipv6=1


### PR DESCRIPTION
## Description

Adds `ttcn3/`, a set of protocol conformance suites written in [TTCN-3](https://ttcn-3.etsi.org/) and built with
[Eclipse Titan](https://projects.eclipse.org/projects/tools.titan), which run against a Zephyr instance over a real network interface.

The companion Zephyr pull request carries the device-side applications,
the Twister harness that drives these suites, the documentation,
and the nightly workflow that runs them.

No existing file is touched, there are 53 new files and no edit to any current tool.
The only addition outside `ttcn3/` is `zeth-l2.conf`, a second interface configuration that
deliberately carries no IP address, for the suites that work below IP and so have to be
the only thing on the link that answers.

### Why

Zephyr's networking tests are almost all in-process ztest: they call the stack's
own API and check what it returns. That cannot see what goes onto the wire, and
it cannot ask the question a standard asks like is this bit set, is this option
present, does this answer go to the address the RFC names. These suites ask it
from outside the device, against an unmodified image.

Writing them turned up five places where Zephyr did not do what the standard
says. Three are already fixed in mainline:

- `41fe8752c58` — the mDNS responder answered a legacy unicast query in
  multicast form (RFC 6762 §6.7)
- `289c14b9103` — the DNS resolver reused one source port for its whole lifetime
- `6a96770a1ea` — the DHCPv4 client counted its transaction identifier up on
  every retransmission (RFC 2131 §4.4.1)

Two more are in the companion Zephyr pull request: the DHCPv4 server answering a
request from another subnet with two NAKs, and duplicate address detection
reporting success for an address whose solicitation was never sent
(RFC 4862 §5.4). Every suite asserts the corrected behaviour, so each is a
regression test as well as a conformance one.

### The suites

| Suite | What it exercises | Cases | Needs |
|---|---|---|---|
| `mdns` | mDNS responder, RFC 6762 | 8 | |
| `dns` | DNS resolver, RFC 1035 | 7 | |
| `dnssd` | DNS-SD service advertisement, RFC 6763 | 6 | |
| `coap` | the ETSI CoAP test cases, RFC 7252 | 8 | parallel mode |
| `mqtt` | MQTT 3.1.1 client | 7 | |
| `sntp` | SNTP client, RFC 4330 | 9 | |
| `dhcpv4` | DHCPv4 client, RFC 2131 | 3 | root |
| `dhcpv4_server` | DHCPv4 server, RFC 2131 | 9 | root |
| `arp` | address resolution, RFC 826 | 5 | root, `zethL2` |
| `ndp` | IPv6 neighbour discovery, RFC 4861/4862 | 8 | root, `zethL2` |
| `tcp` | TCP, RFC 9293 | 8 | root, `zethL2` |

"root" means the suite binds a port that the protocol fixes and that cannot be
moved, or opens a packet socket. "`zethL2`" means it builds its own ethernet
frames and wants the address-less interface. The Zephyr-side harness checks for
both and skips rather than failing when it cannot have them.

The CoAP suite is the exception to everything else here: it does not define its
own test cases but runs the ETSI ones that the Titan project already publishes,
which is why it needs Titan's main controller.

### How it is built

`fetch-modules.sh` once, then `./build.sh <suite>`, with `TTCN3_DIR` pointing at
a Titan installation. `docker/Dockerfile.ttcn3` builds an image with a current
Titan for anyone whose distribution ships an old one. `ttcn3/README.md` covers
the build; everything else, what each suite tests, installing Titan, setting up
the interfaces, running through Twister, adding a suite, is documented in the
Zephyr tree so it sits next to the code under test.

### Third party modules

The suites build against protocol modules and test ports from the Eclipse Titan
project. They are **not vendored**: `modules.txt` names thirteen repositories
under `https://gitlab.eclipse.org/eclipse/titan/` and pins each to a commit, and
`fetch-modules.sh` clones them into `modules/`, which is not in git. A pin moves
by editing that file.

Those modules are Eclipse Public License 2.0; everything written here is Apache
2.0. Both are OSI-approved, which is what Zephyr asks of tooling that never
becomes part of a Zephyr image, see `doc/contribute/external.rst` in the Zephyr
tree. Nothing from them is copied into this repository.

One test port is written here rather than taken from them. Titan publishes
`LANL2asp` for reading and writing ethernet frames, but it captures with libpcap
and opens the handle with a zero read timeout, which on Linux asks the kernel to
wait indefinitely for a capture block to fill. On a link as quiet as a test link
the frames never reach the test, and no parameter changes it.
`common/Ethernet_PT.cc` reads a packet socket instead.

### Testing done

All eleven suites pass against `native_sim` on the current Zephyr main plus the
two fixes in the companion pull request, 78 of 78 cases. Each suite was also
checked for discrimination by deliberately breaking one assertion and confirming
that only that case failed.
